### PR TITLE
Make virtual keyboard a persistant configuration

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -395,7 +395,7 @@ ApplicationWindow {
       id: keyboardAnimation
       onStarted: {
       if(to === 1)
-        inputPanel.visible = true
+        inputPanel.visible = GC.showVirtualKeyboard
       }
       onFinished: {
         if(to === 0)
@@ -404,21 +404,22 @@ ApplicationWindow {
     }
     onTextEnteredChanged: {
       var rectInput = Qt.inputMethod.anchorRectangle
-      if (inputPanel.textEntered) {
-        if(rectInput.bottom > inputPanel.y)
-        {
-          flickableAnimation.to = rectInput.bottom - inputPanel.y + 10
-          flickableAnimation.start()
+      if(inputPanel.textEntered) {
+        if(GC.showVirtualKeyboard) {
+          if(rectInput.bottom > inputPanel.y) {
+            flickableAnimation.to = rectInput.bottom - inputPanel.y + 10
+            flickableAnimation.start()
+          }
+          keyboardAnimation.to = 1
+          keyboardAnimation.duration = 500
+          keyboardAnimation.start()
         }
-        keyboardAnimation.to = 1
-        keyboardAnimation.duration = 500
-        keyboardAnimation.start()
       }
       else {
         if(flickable.contentY !== 0) {
           flickableAnimation.to = 0
           flickableAnimation.start()
-           }
+        }
         keyboardAnimation.to = 0
         keyboardAnimation.duration = 0
         keyboardAnimation.start()

--- a/qml/singletons/GlobalConfig.qml
+++ b/qml/singletons/GlobalConfig.qml
@@ -104,6 +104,11 @@ Item {
     settings.globalSettings.setOption("screen_resolution", resolution);
   }
 
+  readonly property bool showVirtualKeyboard: parseInt(settings.globalSettings.getOption("show_virtual_keyboard", "1"))
+  function setShowVirtualKeyboard(show) {
+    settings.globalSettings.setOption("show_virtual_keyboard", show ? 1 : 0);
+  }
+
 
   /////////////////////////////////////////////////////////////////////////////
   // Common standard margins

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,7 +30,11 @@ int main(int argc, char *argv[])
 {
   //qputenv("QSG_RENDER_LOOP", QByteArray("threaded")); //threaded opengl rendering
   //qputenv("QMLSCENE_DEVICE", QByteArray("softwarecontext")); //software renderer
-  //qputenv("QT_IM_MODULE", QByteArray("qtvirtualkeyboard")); //virtual keyboard
+
+  // We need to pin virtual keyboard on - otherwise Qml complains for unknown
+  // Type 'InputPanel'
+  qputenv("QT_IM_MODULE", QByteArray("qtvirtualkeyboard")); //virtual keyboard
+
   qputenv("QT_VIRTUALKEYBOARD_LAYOUT_PATH", QByteArray("qrc:/qml/vkeyboard/layouts"));
   const bool hasQtVirtualKeyboard = (qgetenv("QT_IM_MODULE") == QByteArray("qtvirtualkeyboard"));
 


### PR DESCRIPTION
Shelve the initial idea to control visibility of virtual keyboard by
environment variable 'QT_IM_MODULE' because in case variable is not set
application won't start complaining

| qrc:/qml/main.qml:385 Type InputPanel unavailable
| qrc:/QtQuick/VirtualKeyboard/content/InputPanel.qml:125 Type Keyboard unavailable
| qrc:/QtQuick/VirtualKeyboard/content/components/Keyboard.qml:36 module "QtQuick.VirtualKeyboard.Plugins" is not installed

For now this setting does not have a GUI backend because

* settings are subject of massive rework anyway
* we might introduce a magic for default value later

Fixes [1]

[1] https://github.com/ZeraGmbH/vf-declarative-gui/issues/41

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>