### PR TITLE
Enforced --no-as-needed for qml libs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,7 @@ target_link_libraries(vf-declarative-gui
     VeinMeta::VfTcp
     VeinMeta::VfQml
     VeinMeta::VfHelpers
+    "-Wl,--no-as-needed"
     ZeraQml::ZVKeyboard
     ZeraQml::zerafa
     ZeraQml::anmlib
@@ -117,6 +118,7 @@ target_link_libraries(vf-declarative-gui
     ZeraQml::zeraveincomponents
     ZeraQml::qwtcharts
     ZeraQml::JsonSettingsQml
+    "-Wl,--as-needed"
     #Other Libs
     ${QWT_LIBRARIES}
     ${glLib}


### PR DESCRIPTION
Libs with Q_COREAPP_STARTUP_FUNCTION must be linked with --no-as-needed.
To achive that we deactivate --as-needed in front and reactivate it after linking
those libs. The rest can be build with global --as-needed

Signed-off-by: bhamacher <b.hamacher@zera.de>