### PR TITLE
ParamViewComparison.qml: Undo accidental change

### DIFF
--- a/qml/controls/error_comparison_params/ParamViewComparison.qml
+++ b/qml/controls/error_comparison_params/ParamViewComparison.qml
@@ -304,7 +304,7 @@ Item {
             // Hmm - we need full reference for currentFactor here
             bottom: validatorEnergy.Data[0] / energyVal.currentFactor;
             top: validatorEnergy.Data[1] / energyVal.currentFactor;
-            decimals: GC.ceilLog10Of1DividedByX(validCCMP.ZLineEditatorEnergy.Data[2] / energyVal.currentFactor)
+            decimals: GC.ceilLog10Of1DividedByX(validatorEnergy.Data[2] / energyVal.currentFactor)
           }
           // overrides for scale
           function doApplyInput(newText) {


### PR DESCRIPTION
There is no validCCMP in the whole project and bug came in with

commit 1ba98eb07e0f189095517337ab79faf1d8ffcba2
Author: bhamacher <b.hamacher@zera.de>
Date:   Wed Jul 22 14:21:05 2020 +0200

    Moved code to vf-qmllibs.
    Following libs are replacing some parts of the code now:
    zeraHelpers
    zeraGlobalConfig
    zeraComponents
    zeraTranslation
    zeraVeinComponents

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>