### PR TITLE
LoggerMenu: set last db/session once only (persistence hack)

### DIFF
--- a/qml/controls/logger/LoggerMenu.qml
+++ b/qml/controls/logger/LoggerMenu.qml
@@ -12,11 +12,13 @@ Item {
     // external
     property real pointSize: 16
     function open() {
+        var oldPersitenceDone = GC.dbPersitenceDone
+        GC.dbPersitenceDone = true
         // Support users: in case there is no database available:
         // * do not show menu
         // * open to settings immediately
         if(loggerEntity.DatabaseReady !== true) {
-            if(loggerEntity.DatabaseFile === "" && GC.currDatabaseFileName !== "") {
+            if(!oldPersitenceDone && loggerEntity.DatabaseFile === "" && GC.currDatabaseFileName !== "") {
                 loggerEntity.DatabaseFile = GC.currDatabaseFileName
                 if(GC.currDatabaseSessionName !== "") {
                     setSessionNameForPersitence = true

--- a/qml/singletons/GlobalConfig.qml
+++ b/qml/singletons/GlobalConfig.qml
@@ -600,6 +600,7 @@ Item {
 
     /////////////////////////////////////////////////////////////////////////////
     // Database persistance settings TODO: let vein handle this
+    property bool dbPersitenceDone: false
     property string currDatabaseFileName: settings.globalSettings.getOption("logger_db_filename", "")
     function setCurrDatabaseFileName(databaseFileName) {
         settings.globalSettings.setOption("logger_db_filename", databaseFileName)


### PR DESCRIPTION
it popped up testing the database gone watcher that the database was re-created
on every menu open. This is a bit too much persitence...

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>