### PR TITLE
LoggerSettings: Allow managing customer data while recording

### DIFF
--- a/qml/controls/logger/LoggerSettings.qml
+++ b/qml/controls/logger/LoggerSettings.qml
@@ -489,7 +489,6 @@ SettingsControls.SettingsView {
                     font.family: FA.old
                     font.pointSize: root.pointSize
                     implicitHeight: root.rowHeight
-                    enabled: loggerEntity.LoggingEnabled === false
                     onClicked: menuStackLayout.showCustomerDataBrowser()
                 }
             }


### PR DESCRIPTION
Customer data is stored into a session when it is created. So there is no
reason to deny changes while recording is running.

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>