### PR TITLE
ApplicationSettings: Remove checkbox for view persistency

### DIFF
--- a/qml/controls/settings/ApplicationSettings.qml
+++ b/qml/controls/settings/ApplicationSettings.qml
@@ -81,29 +81,6 @@ SettingsView {
                 anchors.fill: parent
                 anchors.leftMargin: 16
                 anchors.rightMargin: 16
-                Label {
-                    textFormat: Text.PlainText
-                    text: Z.tr("Remember measurements viewed:")
-                    font.pixelSize: 20
-                    Layout.fillWidth: true
-                }
-                CheckBox {
-                    height: parent.height
-                    Component.onCompleted: checked = GC.keepPagesPesistent
-                    onCheckedChanged: {
-                        GC.setKeepPagesPesistent(checked);
-                    }
-                }
-            }
-        }
-
-        Item {
-            height: root.rowHeight;
-            width: root.rowWidth;
-            RowLayout {
-                anchors.fill: parent
-                anchors.leftMargin: 16
-                anchors.rightMargin: 16
 
                 Label {
                     textFormat: Text.PlainText


### PR DESCRIPTION
* View persistency is so cool so why disable it?
* The text of the checkbox was so misleading that it confused everybody

So As long as nobody comes up with
* good argument why disable persistency is necessary
* a good text for the checkbox
remove it.

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>