### PR TITLE
GlobalSettings: Rework

### DIFF
--- a/appdata.qrc
+++ b/appdata.qrc
@@ -66,6 +66,7 @@
         <file>qml/pages/VectorModulePage.qml</file>
         <file>qml/singletons/GlobalConfig.qml</file>
         <file>qml/singletons/ModuleIntrospection.qml</file>
+        <file>qml/singletons/FunctionTools.qml</file>
         <file>qml/controls/MainToolBar.qml</file>
         <file>qml/controls/PageGridView.qml</file>
         <file>qml/controls/PageView.qml</file>

--- a/qml/controls/MeasModeComboHeader.qml
+++ b/qml/controls/MeasModeComboHeader.qml
@@ -5,6 +5,7 @@ import QtQuick.Controls.Material 2.14
 import VeinEntity 1.0
 import ZeraTranslation  1.0
 import GlobalConfig 1.0
+import FunctionTools 1.0
 import ModuleIntrospection 1.0
 
 Rectangle {
@@ -42,7 +43,7 @@ Rectangle {
         Text {
             text: {
                 let nomFreq = Number(entityIntrospection.ModuleInfo.NominalFrequency)
-                let scaled = GC.doAutoScale(nomFreq, "Hz")
+                let scaled = FT.doAutoScale(nomFreq, "Hz")
                 return scaled[0]+scaled[1]
             }
             font.pointSize: pointSize
@@ -67,7 +68,7 @@ Rectangle {
                 else if(mode.includes("LS")) {
                     unit = "VA"
                 }
-                let scaled = GC.doAutoScale(meterConstant, `/k${unit}h`)
+                let scaled = FT.doAutoScale(meterConstant, `/k${unit}h`)
                 return Math.round(scaled[0]*1000)/1000+scaled[1]
             }
             font.pointSize: pointSize

--- a/qml/controls/RotaryFieldIndicator.qml
+++ b/qml/controls/RotaryFieldIndicator.qml
@@ -22,7 +22,7 @@ Item {
     model: rotaryField.length
     Text {
       text: rotaryField[index];
-      color: GC.systemColorByIndex(parseInt(rotaryField[index]));
+      color: GC.currentColorTable[parseInt(rotaryField[index]-1)]
       font.pixelSize: root.height/1.8
       x: 2 + (root.width/3 * index)
       anchors.verticalCenter: parent.verticalCenter

--- a/qml/controls/error_comparison_common/MeasurementView.qml
+++ b/qml/controls/error_comparison_common/MeasurementView.qml
@@ -6,6 +6,7 @@ import VeinEntity 1.0
 import QwtChart 1.0
 import ZeraTranslation  1.0
 import GlobalConfig 1.0
+import FunctionTools 1.0
 import ModuleIntrospection 1.0
 import ZeraFa 1.0
 import "qrc:/qml/controls" as CCMP
@@ -162,7 +163,7 @@ Item {
                     fontSizeMode: Text.HorizontalFit
                     anchors.bottom: parent.bottom
                     anchors.right: parent.right
-                    text: GC.formatNumber(measurementResult)+"%"
+                    text: FT.formatNumber(measurementResult)+"%"
                 }
             }
         }

--- a/qml/controls/error_comparison_common/MultipleErrorView.qml
+++ b/qml/controls/error_comparison_common/MultipleErrorView.qml
@@ -30,7 +30,7 @@ Rectangle {
 
     onJsonResultsChanged: resultList.recalcModel()
 
-    // Stolen - more or less from GlobalConfig.qml. We should find a more common
+    // Stolen - more or less from FunctionTools.qml. We should find a more common
     // place for this...
     // Reasoning: By having these functions in here we can use property bindings
     // for digitsTotal / decimalPlaces. Doing so is cool: In case they change

--- a/qml/controls/error_comparison_params/ParamViewComparison.qml
+++ b/qml/controls/error_comparison_params/ParamViewComparison.qml
@@ -6,6 +6,7 @@ import VeinEntity 1.0
 import QwtChart 1.0
 import ZeraTranslation  1.0
 import GlobalConfig 1.0
+import FunctionTools 1.0
 import ModuleIntrospection 1.0
 import ZeraComponents 1.0
 import ZeraVeinComponents 1.0
@@ -202,7 +203,7 @@ Item {
                 validator: ZDoubleValidator {
                     bottom: validatorDutConstant.Data[0];
                     top: validatorDutConstant.Data[1];
-                    decimals: GC.ceilLog10Of1DividedByX(validatorDutConstant.Data[2]);
+                    decimals: FT.ceilLog10Of1DividedByX(validatorDutConstant.Data[2]);
                 }
             }
 
@@ -265,7 +266,7 @@ Item {
                         // Hmm - we need full reference for currentFactor here
                         bottom: validatorEnergy.Data[0] / energyVal.currentFactor;
                         top: validatorEnergy.Data[1] / energyVal.currentFactor;
-                        decimals: GC.ceilLog10Of1DividedByX(validatorEnergy.Data[2] / energyVal.currentFactor)
+                        decimals: FT.ceilLog10Of1DividedByX(validatorEnergy.Data[2] / energyVal.currentFactor)
                     }
                     // overrides for scale
                     function doApplyInput(newText) {
@@ -279,11 +280,11 @@ Item {
                         var fltVal = parseFloat(text) / currentFactor
                         // * we cannot use validator.decimals - it is updated too late
                         // * multiple back and forth conversion to round value to digit (otherwise field remains red)
-                        var strVal = String(Number(fltVal.toFixed(GC.ceilLog10Of1DividedByX(validatorEnergy.Data[2] / currentFactor))))
+                        var strVal = String(Number(fltVal.toFixed(FT.ceilLog10Of1DividedByX(validatorEnergy.Data[2] / currentFactor))))
                         textField.text = strVal.replace(ZLocale.getDecimalPoint() === "," ? "." : ",", ZLocale.getDecimalPoint())
                     }
                     function hasAlteredValue() {
-                        var expVal = Math.pow(10, GC.ceilLog10Of1DividedByX(validatorEnergy.Data[2] / currentFactor))
+                        var expVal = Math.pow(10, FT.ceilLog10Of1DividedByX(validatorEnergy.Data[2] / currentFactor))
                         var fieldVal = parseFloat(ZLocale.strToCLocale(textField.text, isNumeric, isDouble)) * expVal
                         var textVal = parseFloat(text) * expVal / currentFactor
                         return Math.abs(fieldVal-textVal) > 0.1
@@ -357,7 +358,7 @@ Item {
                     validator: ZDoubleValidator {
                         bottom: validatorMrate.Data[0];
                         top: validatorMrate.Data[1];
-                        decimals: GC.ceilLog10Of1DividedByX(validatorMrate.Data[2]);
+                        decimals: FT.ceilLog10Of1DividedByX(validatorMrate.Data[2]);
                     }
                 }
             }
@@ -455,7 +456,7 @@ Item {
                 validator: ZDoubleValidator {
                     bottom: validatorUpperLimit.Data[0];
                     top: validatorUpperLimit.Data[1];
-                    decimals: Math.min(GC.ceilLog10Of1DividedByX(validatorUpperLimit.Data[2]), GC.decimalPlaces);
+                    decimals: Math.min(FT.ceilLog10Of1DividedByX(validatorUpperLimit.Data[2]), GC.decimalPlaces);
                 }
             }
             Label {
@@ -496,7 +497,7 @@ Item {
                 validator: ZDoubleValidator {
                     bottom: validatorLowerLimit.Data[0];
                     top: validatorLowerLimit.Data[1];
-                    decimals: Math.min(GC.ceilLog10Of1DividedByX(validatorLowerLimit.Data[2]), GC.decimalPlaces);
+                    decimals: Math.min(FT.ceilLog10Of1DividedByX(validatorLowerLimit.Data[2]), GC.decimalPlaces);
                 }
             }
             Label {

--- a/qml/controls/error_comparison_params/ParamViewRegister.qml
+++ b/qml/controls/error_comparison_params/ParamViewRegister.qml
@@ -6,6 +6,7 @@ import VeinEntity 1.0
 import QwtChart 1.0
 import ZeraTranslation  1.0
 import GlobalConfig 1.0
+import FunctionTools 1.0
 import ModuleIntrospection 1.0
 import ZeraComponents 1.0
 import ZeraVeinComponents 1.0
@@ -198,7 +199,7 @@ Item {
                 validator: ZDoubleValidator {
                     bottom: validatorMeasTime.Data[0];
                     top: validatorMeasTime.Data[1];
-                    decimals: GC.ceilLog10Of1DividedByX(validatorMeasTime.Data[2]);
+                    decimals: FT.ceilLog10Of1DividedByX(validatorMeasTime.Data[2]);
                 }
             }
             Label {
@@ -239,7 +240,7 @@ Item {
                 validator: ZDoubleValidator {
                     bottom: validatorT0Input.Data[0];
                     top: validatorT0Input.Data[1];
-                    decimals: GC.ceilLog10Of1DividedByX(validatorT0Input.Data[2]);
+                    decimals: FT.ceilLog10Of1DividedByX(validatorT0Input.Data[2]);
                 }
 
             }
@@ -277,7 +278,7 @@ Item {
                 validator: ZDoubleValidator {
                     bottom: validatorT1Input.Data[0];
                     top: validatorT1Input.Data[1];
-                    decimals: GC.ceilLog10Of1DividedByX(validatorT1Input.Data[2]);
+                    decimals: FT.ceilLog10Of1DividedByX(validatorT1Input.Data[2]);
                 }
             }
             VFComboBox {
@@ -324,7 +325,7 @@ Item {
                 validator: ZDoubleValidator {
                     bottom: validatorUpperLimit.Data[0];
                     top: validatorUpperLimit.Data[1];
-                    decimals: Math.min(GC.ceilLog10Of1DividedByX(validatorUpperLimit.Data[2]), GC.decimalPlaces);
+                    decimals: Math.min(FT.ceilLog10Of1DividedByX(validatorUpperLimit.Data[2]), GC.decimalPlaces);
                 }
             }
             Label {
@@ -364,7 +365,7 @@ Item {
                 validator: ZDoubleValidator {
                     bottom: validatorLowerLimit.Data[0];
                     top: validatorLowerLimit.Data[1];
-                    decimals: Math.min(GC.ceilLog10Of1DividedByX(validatorLowerLimit.Data[2]), GC.decimalPlaces);
+                    decimals: Math.min(FT.ceilLog10Of1DividedByX(validatorLowerLimit.Data[2]), GC.decimalPlaces);
                 }
             }
             Label {

--- a/qml/controls/fft_module/FftCharts.qml
+++ b/qml/controls/fft_module/FftCharts.qml
@@ -4,6 +4,7 @@ import QtQuick.Controls.Material 2.0
 import VeinEntity 1.0
 import QwtChart 1.0
 import GlobalConfig 1.0
+import FunctionTools 1.0
 import ModuleIntrospection 1.0
 import ZeraTranslation 1.0
 import "qrc:/qml/controls" as CCMP
@@ -77,18 +78,18 @@ ListView {
             //index starts with 1
             readonly property string componentName: String("ACT_THDN%1").arg(leftChannels[index]+1);
             readonly property string unit: ModuleIntrospection.thdnIntrospection.ComponentInfo[componentName].Unit
-            text: strThdn + GC.formatNumber(thdnModule[componentName]) + unit
-            color: GC.systemColorByIndex(leftChannels[index]+1)
+            text: strThdn + FT.formatNumber(thdnModule[componentName]) + unit
+            color: GC.currentColorTable[leftChannels[index]]
         }
         Text {
             id: thdnTextI
             //index starts with 1
             readonly property string componentName: String("ACT_THDN%1").arg(rightChannels[index]+1);
             readonly property string unit: ModuleIntrospection.thdnIntrospection.ComponentInfo[componentName].Unit
-            text: strThdn + GC.formatNumber(thdnModule[componentName]) + unit
+            text: strThdn + FT.formatNumber(thdnModule[componentName]) + unit
             anchors.right: parent.right
             anchors.rightMargin: 8
-            color: GC.systemColorByIndex(rightChannels[index]+1)
+            color: GC.currentColorTable[rightChannels[index]]
         }
 
         FftBarChart {
@@ -104,8 +105,8 @@ ListView {
             bottomLabelsEnabled: true
             logScaleLeftAxis: false
             logScaleRightAxis: false
-            colorLeftAxis: GC.systemColorByIndex(leftChannels[index]+1)
-            colorRightAxis: GC.systemColorByIndex(rightChannels[index]+1)
+            colorLeftAxis: GC.currentColorTable[leftChannels[index]]
+            colorRightAxis: GC.currentColorTable[rightChannels[index]]
 
             leftValue: fftModule[String("ACT_FFT%1").arg(leftChannels[index]+1)]
             rightValue: fftModule[String("ACT_FFT%1").arg(rightChannels[index]+1)]

--- a/qml/controls/fft_module/FftTable.qml
+++ b/qml/controls/fft_module/FftTable.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.0
 import QtQuick.Controls.Material 2.0
 import VeinEntity 1.0
 import GlobalConfig 1.0
+import FunctionTools 1.0
 import ZeraGlueLogic 1.0
 import ZeraTranslation  1.0
 import ModuleIntrospection 1.0
@@ -94,7 +95,7 @@ Item {
                         font.pixelSize: rowHeight*0.5
                         font.family: "Droid Sans Mono"
                         font.bold: true
-                        color: GC.getColorByIndex(index+1)
+                        color: FT.getColorByIndex(index+1)
                         horizontalAlignment: Text.AlignRight
                         verticalAlignment: Text.AlignVCenter
                         textFormat: Text.PlainText
@@ -130,8 +131,8 @@ Item {
                     height: root.rowHeight
                     readonly property string componentName: String("ACT_THDN%1").arg(index+1);
                     readonly property string unit: ModuleIntrospection.thdnIntrospection.ComponentInfo[componentName].Unit
-                    text: GC.formatNumber(thdnModule[componentName]) + unit
-                    textColor: GC.getColorByIndex(index+1)
+                    text: FT.formatNumber(thdnModule[componentName]) + unit
+                    textColor: FT.getColorByIndex(index+1)
                     font.pixelSize: rowHeight*0.5
                     border.color: "#444" //disable border transparency
                 }
@@ -169,7 +170,7 @@ Item {
                         border.color: "#444" //disable border transparency
                         text: (relativeView ? " [%]" : " ["+ModuleIntrospection.fftIntrospection.ComponentInfo["ACT_FFT"+parseInt(index+1)].Unit+"]");
                         textHorizontalAlignment: Label.AlignHCenter
-                        textColor: GC.getColorByIndex(index+1)
+                        textColor: FT.getColorByIndex(index+1)
                         font.pixelSize: rowHeight*0.5
                         font.bold: true
                     }
@@ -181,7 +182,7 @@ Item {
                             color: GC.tableShadeColor
                             border.color: "#444" //disable border transparency
                             text: Z.tr("Phase") + " [°)"
-                            textColor: GC.getColorByIndex(index+1)
+                            textColor: FT.getColorByIndex(index+1)
                             font.pixelSize: rowHeight*0.5
                             font.bold: true
                         }
@@ -222,7 +223,7 @@ Item {
                         width: root.columnWidth
                         height: root.rowHeight
                         property string unit: index===1 && relativeView ? ModuleIntrospection.fftIntrospection.ComponentInfo.ACT_FFT1.Unit : ""
-                        text: AmplitudeL1 !== undefined ? GC.formatNumber(AmplitudeL1) + unit : text
+                        text: AmplitudeL1 !== undefined ? FT.formatNumber(AmplitudeL1) + unit : text
                         textColor: GC.colorUL1
                         font.pixelSize: rowHeight*0.5
                     }
@@ -231,7 +232,7 @@ Item {
                         sourceComponent: CCMP.GridItem {
                             width: root.columnWidth
                             height: root.rowHeight
-                            text: VectorL1 !== undefined ? GC.formatNumber(VectorL1) : text
+                            text: VectorL1 !== undefined ? FT.formatNumber(VectorL1) : text
                             textColor: GC.colorUL1
                             font.pixelSize: rowHeight*0.5
                         }
@@ -240,7 +241,7 @@ Item {
                         width: root.columnWidth
                         height: root.rowHeight
                         property string unit: index===1 && relativeView ? ModuleIntrospection.fftIntrospection.ComponentInfo.ACT_FFT2.Unit : ""
-                        text: AmplitudeL2 !== undefined ? GC.formatNumber(AmplitudeL2) + unit : text
+                        text: AmplitudeL2 !== undefined ? FT.formatNumber(AmplitudeL2) + unit : text
                         textColor: GC.colorUL2
                         font.pixelSize: rowHeight*0.5
                     }
@@ -249,7 +250,7 @@ Item {
                         sourceComponent: CCMP.GridItem {
                             width: root.columnWidth
                             height: root.rowHeight
-                            text: VectorL2 !== undefined ? GC.formatNumber(VectorL2) : text
+                            text: VectorL2 !== undefined ? FT.formatNumber(VectorL2) : text
                             textColor: GC.colorUL2
                             font.pixelSize: rowHeight*0.5
                         }
@@ -258,7 +259,7 @@ Item {
                         width: root.columnWidth
                         height: root.rowHeight
                         property string unit: index===1 && relativeView ? ModuleIntrospection.fftIntrospection.ComponentInfo.ACT_FFT3.Unit : ""
-                        text: AmplitudeL3 !== undefined ? GC.formatNumber(AmplitudeL3) + unit : text
+                        text: AmplitudeL3 !== undefined ? FT.formatNumber(AmplitudeL3) + unit : text
                         textColor: GC.colorUL3
                         font.pixelSize: rowHeight*0.5
                     }
@@ -267,7 +268,7 @@ Item {
                         sourceComponent: CCMP.GridItem {
                             width: root.columnWidth
                             height: root.rowHeight
-                            text: VectorL3 !== undefined ? GC.formatNumber(VectorL3) : text
+                            text: VectorL3 !== undefined ? FT.formatNumber(VectorL3) : text
                             textColor: GC.colorUL3
                             font.pixelSize: rowHeight*0.5
                         }
@@ -276,7 +277,7 @@ Item {
                         width: root.columnWidth
                         height: root.rowHeight
                         property string unit: index===1 && relativeView ? ModuleIntrospection.fftIntrospection.ComponentInfo.ACT_FFT4.Unit : ""
-                        text: AmplitudeL4 !== undefined ? GC.formatNumber(AmplitudeL4) + unit : text
+                        text: AmplitudeL4 !== undefined ? FT.formatNumber(AmplitudeL4) + unit : text
                         textColor: GC.colorIL1
                         font.pixelSize: rowHeight*0.5
                     }
@@ -285,7 +286,7 @@ Item {
                         sourceComponent: CCMP.GridItem {
                             width: root.columnWidth
                             height: root.rowHeight
-                            text: VectorL4 !== undefined ? GC.formatNumber(VectorL4) : text
+                            text: VectorL4 !== undefined ? FT.formatNumber(VectorL4) : text
                             textColor: GC.colorIL1
                             font.pixelSize: rowHeight*0.5
                         }
@@ -294,7 +295,7 @@ Item {
                         width: root.columnWidth
                         height: root.rowHeight
                         property string unit: index===1 && relativeView ? ModuleIntrospection.fftIntrospection.ComponentInfo.ACT_FFT5.Unit : ""
-                        text: AmplitudeL5 !== undefined ? GC.formatNumber(AmplitudeL5) + unit : text
+                        text: AmplitudeL5 !== undefined ? FT.formatNumber(AmplitudeL5) + unit : text
                         textColor: GC.colorIL2
                         font.pixelSize: rowHeight*0.5
                     }
@@ -303,7 +304,7 @@ Item {
                         sourceComponent: CCMP.GridItem {
                             width: root.columnWidth
                             height: root.rowHeight
-                            text: VectorL5 !== undefined ? GC.formatNumber(VectorL5) : text
+                            text: VectorL5 !== undefined ? FT.formatNumber(VectorL5) : text
                             textColor: GC.colorIL2
                             font.pixelSize: rowHeight*0.5
                         }
@@ -312,7 +313,7 @@ Item {
                         width: root.columnWidth
                         height: root.rowHeight
                         property string unit: index===1 && relativeView ? ModuleIntrospection.fftIntrospection.ComponentInfo.ACT_FFT6.Unit : ""
-                        text: AmplitudeL6 !== undefined ? GC.formatNumber(AmplitudeL6) + unit : text
+                        text: AmplitudeL6 !== undefined ? FT.formatNumber(AmplitudeL6) + unit : text
                         textColor: GC.colorIL3
                         font.pixelSize: rowHeight*0.5
                     }
@@ -321,7 +322,7 @@ Item {
                         sourceComponent: CCMP.GridItem {
                             width: root.columnWidth
                             height: root.rowHeight
-                            text: VectorL6 !== undefined ? GC.formatNumber(VectorL6) : text
+                            text: VectorL6 !== undefined ? FT.formatNumber(VectorL6) : text
                             textColor: GC.colorIL3
                             font.pixelSize: rowHeight*0.5
                         }
@@ -332,7 +333,7 @@ Item {
                             width: root.columnWidth
                             height: root.rowHeight
                             property string unit: index===1 && relativeView ? ModuleIntrospection.fftIntrospection.ComponentInfo.ACT_FFT7.Unit : ""
-                            text: AmplitudeL7 !== undefined ? GC.formatNumber(AmplitudeL7) + unit : text
+                            text: AmplitudeL7 !== undefined ? FT.formatNumber(AmplitudeL7) + unit : text
                             textColor: GC.colorUAux1
                             font.pixelSize: rowHeight*0.5
                         }
@@ -342,7 +343,7 @@ Item {
                         sourceComponent: CCMP.GridItem {
                             width: root.columnWidth
                             height: root.rowHeight
-                            text: VectorL7 !== undefined ? GC.formatNumber(VectorL7) : text
+                            text: VectorL7 !== undefined ? FT.formatNumber(VectorL7) : text
                             textColor: GC.colorUAux1
                             font.pixelSize: rowHeight*0.5
                         }
@@ -353,7 +354,7 @@ Item {
                             width: root.columnWidth
                             height: root.rowHeight
                             property string unit: index===1 && relativeView ? ModuleIntrospection.fftIntrospection.ComponentInfo.ACT_FFT8.Unit : ""
-                            text: AmplitudeL8 !== undefined ? GC.formatNumber(AmplitudeL8) + unit : text
+                            text: AmplitudeL8 !== undefined ? FT.formatNumber(AmplitudeL8) + unit : text
                             textColor: GC.colorIAux1
                             font.pixelSize: rowHeight*0.5
                         }
@@ -363,7 +364,7 @@ Item {
                         sourceComponent: CCMP.GridItem {
                             width: root.columnWidth
                             height: root.rowHeight
-                            text: VectorL8 !== undefined ? GC.formatNumber(VectorL8) : text
+                            text: VectorL8 !== undefined ? FT.formatNumber(VectorL8) : text
                             textColor: GC.colorIAux1
                             font.pixelSize: rowHeight*0.5
                         }

--- a/qml/controls/harmonic_power_module/HarmonicPowerCharts.qml
+++ b/qml/controls/harmonic_power_module/HarmonicPowerCharts.qml
@@ -95,7 +95,7 @@ Item {
 
                     titleLeftAxis: getTitleLabel();
                     bottomLabelsEnabled: true
-                    colorLeftAxis: GC.systemColorByIndex(index+1)
+                    colorLeftAxis: GC.currentColorTable[index]
 
                     pValueList: power3Module[String("ACT_HPP%1").arg(index+1)];
                     qValueList: power3Module[String("ACT_HPQ%1").arg(index+1)];

--- a/qml/controls/harmonic_power_module/HarmonicPowerTable.qml
+++ b/qml/controls/harmonic_power_module/HarmonicPowerTable.qml
@@ -5,6 +5,7 @@ import QtQuick.Controls 2.0
 import QtQuick.Controls.Material 2.0
 import VeinEntity 1.0
 import GlobalConfig 1.0
+import FunctionTools 1.0
 import ZeraGlueLogic 1.0
 import ZeraTranslation  1.0
 import ModuleIntrospection 1.0
@@ -79,7 +80,7 @@ Item {
                         color: GC.tableShadeColor
                         border.color: "#444" //disable border transparency
                         text: ModuleIntrospection.p3m1Introspection.ComponentInfo[String("ACT_HPP%1").arg(index+1)].ChannelName + relativeUnit; //P
-                        textColor: GC.getColorByIndex(index+1)
+                        textColor: FT.getColorByIndex(index+1)
                         font.bold: true
                     }
                     CCMP.GridItem {
@@ -88,7 +89,7 @@ Item {
                         color: GC.tableShadeColor
                         border.color: "#444" //disable border transparency
                         text: ModuleIntrospection.p3m1Introspection.ComponentInfo[String("ACT_HPQ%1").arg(index+1)].ChannelName + relativeUnit; //Q
-                        textColor: GC.getColorByIndex(index+1)
+                        textColor: FT.getColorByIndex(index+1)
                         font.bold: true
                     }
                     CCMP.GridItem {
@@ -97,7 +98,7 @@ Item {
                         color: GC.tableShadeColor
                         border.color: "#444" //disable border transparency
                         text: ModuleIntrospection.p3m1Introspection.ComponentInfo[String("ACT_HPS%1").arg(index+1)].ChannelName + relativeUnit; //S
-                        textColor: GC.getColorByIndex(index+1)
+                        textColor: FT.getColorByIndex(index+1)
                         font.bold: true
                     }
                 }
@@ -136,21 +137,21 @@ Item {
                     CCMP.GridItem {
                         width: root.columnWidth
                         height: root.rowHeight
-                        text: (PowerS1P !== undefined ? GC.formatNumber(PowerS1P) : "") + (relativeView && index===1 ? ModuleIntrospection.p3m1Introspection.ComponentInfo.ACT_HPP1.Unit : "")
+                        text: (PowerS1P !== undefined ? FT.formatNumber(PowerS1P) : "") + (relativeView && index===1 ? ModuleIntrospection.p3m1Introspection.ComponentInfo.ACT_HPP1.Unit : "")
                         textColor: GC.colorUL1
                         font.pixelSize: rowHeight*0.5
                     }
                     CCMP.GridItem {
                         width: root.columnWidth
                         height: root.rowHeight
-                        text: (PowerS1Q !== undefined ? GC.formatNumber(PowerS1Q) : "") + (relativeView && index===1 ? ModuleIntrospection.p3m1Introspection.ComponentInfo.ACT_HPQ1.Unit : "")
+                        text: (PowerS1Q !== undefined ? FT.formatNumber(PowerS1Q) : "") + (relativeView && index===1 ? ModuleIntrospection.p3m1Introspection.ComponentInfo.ACT_HPQ1.Unit : "")
                         textColor: GC.colorUL1
                         font.pixelSize: rowHeight*0.5
                     }
                     CCMP.GridItem {
                         width: root.columnWidth
                         height: root.rowHeight
-                        text: (PowerS1S !== undefined ? GC.formatNumber(PowerS1S) : "") + (relativeView && index===1 ? ModuleIntrospection.p3m1Introspection.ComponentInfo.ACT_HPS1.Unit : "")
+                        text: (PowerS1S !== undefined ? FT.formatNumber(PowerS1S) : "") + (relativeView && index===1 ? ModuleIntrospection.p3m1Introspection.ComponentInfo.ACT_HPS1.Unit : "")
                         textColor: GC.colorUL1
                         font.pixelSize: rowHeight*0.5
                     }
@@ -158,21 +159,21 @@ Item {
                     CCMP.GridItem {
                         width: root.columnWidth
                         height: root.rowHeight
-                        text: (PowerS2P !== undefined ? GC.formatNumber(PowerS2P) : "") + (relativeView && index===1 ? ModuleIntrospection.p3m1Introspection.ComponentInfo.ACT_HPP2.Unit : "")
+                        text: (PowerS2P !== undefined ? FT.formatNumber(PowerS2P) : "") + (relativeView && index===1 ? ModuleIntrospection.p3m1Introspection.ComponentInfo.ACT_HPP2.Unit : "")
                         textColor: GC.colorUL2
                         font.pixelSize: rowHeight*0.5
                     }
                     CCMP.GridItem {
                         width: root.columnWidth
                         height: root.rowHeight
-                        text: (PowerS2Q !== undefined ? GC.formatNumber(PowerS2Q) : "") + (relativeView && index===1 ? ModuleIntrospection.p3m1Introspection.ComponentInfo.ACT_HPQ2.Unit : "")
+                        text: (PowerS2Q !== undefined ? FT.formatNumber(PowerS2Q) : "") + (relativeView && index===1 ? ModuleIntrospection.p3m1Introspection.ComponentInfo.ACT_HPQ2.Unit : "")
                         textColor: GC.colorUL2
                         font.pixelSize: rowHeight*0.5
                     }
                     CCMP.GridItem {
                         width: root.columnWidth
                         height: root.rowHeight
-                        text: (PowerS2S !== undefined ? GC.formatNumber(PowerS2S) : "") + (relativeView && index===1 ? ModuleIntrospection.p3m1Introspection.ComponentInfo.ACT_HPS2.Unit : "")
+                        text: (PowerS2S !== undefined ? FT.formatNumber(PowerS2S) : "") + (relativeView && index===1 ? ModuleIntrospection.p3m1Introspection.ComponentInfo.ACT_HPS2.Unit : "")
                         textColor: GC.colorUL2
                         font.pixelSize: rowHeight*0.5
                     }
@@ -180,21 +181,21 @@ Item {
                     CCMP.GridItem {
                         width: root.columnWidth
                         height: root.rowHeight
-                        text: (PowerS3P !== undefined ? GC.formatNumber(PowerS3P) : "") + (relativeView && index===1 ? ModuleIntrospection.p3m1Introspection.ComponentInfo.ACT_HPP3.Unit : "")
+                        text: (PowerS3P !== undefined ? FT.formatNumber(PowerS3P) : "") + (relativeView && index===1 ? ModuleIntrospection.p3m1Introspection.ComponentInfo.ACT_HPP3.Unit : "")
                         textColor: GC.colorUL3
                         font.pixelSize: rowHeight*0.5
                     }
                     CCMP.GridItem {
                         width: root.columnWidth
                         height: root.rowHeight
-                        text: (PowerS3Q !== undefined ? GC.formatNumber(PowerS3Q) : "") + (relativeView && index===1 ? ModuleIntrospection.p3m1Introspection.ComponentInfo.ACT_HPQ3.Unit : "")
+                        text: (PowerS3Q !== undefined ? FT.formatNumber(PowerS3Q) : "") + (relativeView && index===1 ? ModuleIntrospection.p3m1Introspection.ComponentInfo.ACT_HPQ3.Unit : "")
                         textColor: GC.colorUL3
                         font.pixelSize: rowHeight*0.5
                     }
                     CCMP.GridItem {
                         width: root.columnWidth
                         height: root.rowHeight
-                        text: (PowerS3S !== undefined ? GC.formatNumber(PowerS3S) : "") + (relativeView && index===1 ? ModuleIntrospection.p3m1Introspection.ComponentInfo.ACT_HPS3.Unit : "")
+                        text: (PowerS3S !== undefined ? FT.formatNumber(PowerS3S) : "") + (relativeView && index===1 ? ModuleIntrospection.p3m1Introspection.ComponentInfo.ACT_HPS3.Unit : "")
                         textColor: GC.colorUL3
                         font.pixelSize: rowHeight*0.5
                     }

--- a/qml/controls/logger/LoggerMenu.qml
+++ b/qml/controls/logger/LoggerMenu.qml
@@ -3,6 +3,7 @@ import QtQuick.Layouts 1.12
 import QtQuick.Controls 2.12
 import QtQuick.Controls.Material 2.12
 import GlobalConfig 1.0
+import FunctionTools 1.0
 import VeinEntity 1.0
 import ZeraTranslation  1.0
 import ZeraFa 1.0
@@ -162,7 +163,7 @@ Item {
                 if(contentTypeRadioToSet === GC.contentTypeEnum.CONTENT_TYPE_CONTEXT) {
                     radioContextSpecific = radio
                 }
-                if(contentTypeRadioToSet === GC.getLoggerContentType()) {
+                if(contentTypeRadioToSet === GC.loggerContentType) {
                     radio.checked = true
                     radioChecked = true
                     break;
@@ -341,7 +342,7 @@ Item {
         MenuItem { // Start/Stop
             text: loggerEntity.LoggingEnabled === true ?
                       FA.icon(FA.fa_stop) + Z.tr("Stop logging") + (loggerEntity.ScheduledLoggingEnabled === true ?
-                      (" " + GC.msToTime(loggerEntity.ScheduledLoggingCountdown)) : "") :
+                      (" " + FT.msToTime(loggerEntity.ScheduledLoggingCountdown)) : "") :
                       FA.icon(FA.fa_play) + Z.tr("Start logging")
 
             enabled: loggerEntity.DatabaseReady === true &&

--- a/qml/controls/logger/LoggerSettings.qml
+++ b/qml/controls/logger/LoggerSettings.qml
@@ -9,6 +9,7 @@ import ZeraTranslation  1.0
 import ZeraTranslationBackend  1.0
 import ZeraLocale 1.0
 import GlobalConfig 1.0
+import FunctionTools 1.0
 import ZeraComponents 1.0
 import ZeraVeinComponents 1.0
 import ZeraFa 1.0
@@ -514,12 +515,12 @@ SettingsControls.SettingsView {
 
                     // overrides
                     function doApplyInput(newText) {
-                        entity[controlPropertyName] = GC.timeToMs(newText)
+                        entity[controlPropertyName] = FT.timeToMs(newText)
                         // wait to be applied
                         return false
                     }
                     function transformIncoming(t_incoming) {
-                        return GC.msToTime(t_incoming);
+                        return FT.msToTime(t_incoming);
                     }
                     function hasValidInput() {
                         var regex = /(?!^00:00:00$)[0-9][0-9]:[0-5][0-9]:[0-5][0-9]/
@@ -544,7 +545,7 @@ SettingsControls.SettingsView {
                 Label {
                     visible: loggerEntity.LoggingEnabled === true && loggerEntity.ScheduledLoggingEnabled === true
                     font.pointSize: root.pointSize
-                    property string countDown: GC.msToTime(loggerEntity.ScheduledLoggingCountdown);
+                    property string countDown: FT.msToTime(loggerEntity.ScheduledLoggingCountdown);
                     height: root.rowHeight
                     text: countDown;
                 }

--- a/qml/controls/range_module/RangeIndicator.qml
+++ b/qml/controls/range_module/RangeIndicator.qml
@@ -4,6 +4,7 @@ import VeinEntity 1.0
 import QtQuick.Controls 2.0
 import QtQuick.Controls.Material 2.0
 import GlobalConfig 1.0
+import FunctionTools 1.0
 import ZeraFa 1.0
 
 
@@ -108,7 +109,7 @@ Loader {
                         fontSizeMode: Label.HorizontalFit
                         anchors.verticalCenter: parent.verticalCenter
                         text: ModuleIntrospection.rangeIntrospection.ComponentInfo["PAR_Channel"+parseInt(modelData+1)+"Range"].ChannelName + ": "
-                        color: GC.getColorByIndex(modelData+1, rangeGrouping)
+                        color: FT.getColorByIndex(modelData+1, rangeGrouping)
                         font.bold: true
                     }
                     Label {
@@ -145,7 +146,7 @@ Loader {
                         fontSizeMode: Label.HorizontalFit
                         anchors.verticalCenter: parent.verticalCenter
                         text: ModuleIntrospection.rangeIntrospection.ComponentInfo["PAR_Channel"+parseInt(modelData+1)+"Range"].ChannelName + ": "
-                        color: GC.getColorByIndex(modelData+1, rangeGrouping)
+                        color: FT.getColorByIndex(modelData+1, rangeGrouping)
                         font.bold: true
                     }
                     Label {

--- a/qml/controls/range_module/RangeMenu.qml
+++ b/qml/controls/range_module/RangeMenu.qml
@@ -5,6 +5,7 @@ import QtQuick.Controls.Material 2.0
 import QtGraphicalEffects 1.0
 import ModuleIntrospection 1.0
 import GlobalConfig 1.0
+import FunctionTools 1.0
 import ZeraTranslation  1.0
 import ZeraVeinComponents 1.0
 
@@ -75,7 +76,7 @@ Item {
                 }
             }
             else {
-                retVal = GC.systemColorByIndex(rangIndex)
+                retVal = GC.currentColorTable[rangIndex-1]
             }
             return retVal;
         }
@@ -178,7 +179,7 @@ Item {
                 width: grid.cellWidth*4
                 Label {
                     text: ModuleIntrospection.rangeIntrospection.ComponentInfo["PAR_Channel"+parseInt(modelData+1)+"Range"].ChannelName
-                    color: GC.getColorByIndex(modelData+1, root.groupingActive)
+                    color: FT.getColorByIndex(modelData+1, root.groupingActive)
                     anchors.bottom: parent.top
                     anchors.bottomMargin: -(parent.height/3)
                     anchors.horizontalCenter: parent.horizontalCenter
@@ -217,7 +218,7 @@ Item {
                 width: grid.cellWidth*4
                 Label {
                     text: ModuleIntrospection.rangeIntrospection.ComponentInfo["PAR_Channel"+parseInt(modelData+1)+"Range"].ChannelName
-                    color: GC.getColorByIndex(modelData+1, root.groupingActive)
+                    color: FT.getColorByIndex(modelData+1, root.groupingActive)
                     anchors.bottom: parent.top
                     anchors.bottomMargin: -(parent.height/3)
                     anchors.horizontalCenter: parent.horizontalCenter

--- a/qml/controls/range_module/RangePeak.qml
+++ b/qml/controls/range_module/RangePeak.qml
@@ -5,6 +5,7 @@ import QtQuick.Controls.Material 2.0
 import VeinEntity 1.0
 import ModuleIntrospection 1.0
 import GlobalConfig 1.0
+import FunctionTools 1.0
 import QwtChart 1.0
 import ZeraTranslation  1.0
 
@@ -43,7 +44,7 @@ Item {
         //toFixed(2) because of visual screen flickering of bars, bug in Qwt?
         //Math.sqrt(2) because peak value are compared with rms rejection
         property real relativeValue: Number((100 * rangeModule["ACT_Channel"+(index+1)+"Peak"] / (Math.sqrt(2) * rangeModule["INF_Channel"+(index+1)+"ActREJ"])).toFixed(2))
-        color: GC.getColorByIndex(index+1, root.rangeGrouping)
+        color: FT.getColorByIndex(index+1, root.rangeGrouping)
         Component.onCompleted: {
           peakChart.peakBars.push(this);
           peakChart.peakBarsChanged();

--- a/qml/controls/settings/ApplicationSettings.qml
+++ b/qml/controls/settings/ApplicationSettings.qml
@@ -55,10 +55,10 @@ SettingsView {
         }
         function getCurrentColor(index) {
             if(!allColorChangePending) {
-                return GC.systemColorByIndex(index)
+                return GC.currentColorTable[index-1]
             }
             else {
-                return GC.getDefaultColorByIndex(index, nextColorScheme)
+                return GC.defaultColorsTableArray[nextColorScheme][index-1]
             }
         }
 
@@ -198,7 +198,7 @@ SettingsView {
             width: defaultColoursPopup.width * 0.125
             anchors.verticalCenter: sliderRowBrightness.bottom
             onClicked: {
-                GC.setDefaultBrighnesses()
+                GC.restoreDefaultBrighnesses()
                 sliderCurrent.value = GC.currentBrightness
                 sliderBlack.value = GC.blackBrightness
             }
@@ -210,7 +210,7 @@ SettingsView {
             anchors.right: parent.right
             anchors.bottom: parent.bottom
             spacing: 4
-            readonly property int countColourThemes: GC.defaultColorTable.length
+            readonly property int countColourThemes: GC.defaultColorsTableArray.length
             model: countColourThemes
             delegate: Rectangle {
                 id: lineDelegate
@@ -235,7 +235,7 @@ SettingsView {
                             Layout.fillHeight: true
                             text: ModuleIntrospection.rangeIntrospection.ComponentInfo[`PAR_Channel${index+1}Range`].ChannelName
                             font.pointSize: colourListView.height * 0.040
-                            color: GC.defaultColorTable[lineDelegate.row][index]
+                            color: GC.defaultColorsTableArray[lineDelegate.row][index]
                             verticalAlignment: Text.AlignVCenter
                             textFormat: Text.PlainText
                         }

--- a/qml/controls/settings/SettingsInterval.qml
+++ b/qml/controls/settings/SettingsInterval.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.0
 import QtQuick.Controls.Material 2.0
 import QtQuick.Layouts 1.2
 import GlobalConfig 1.0
+import FunctionTools 1.0
 import ModuleIntrospection 1.0
 import VeinEntity 1.0
 import ZeraTranslation  1.0
@@ -84,7 +85,7 @@ Column {
                         id: validatorTime
                         bottom: timeIntrospection.ComponentInfo.PAR_Interval.Validation.Data[0];
                         top: timeIntrospection.ComponentInfo.PAR_Interval.Validation.Data[1];
-                        decimals: GC.ceilLog10Of1DividedByX(timeIntrospection.ComponentInfo.PAR_Interval.Validation.Data[2]);
+                        decimals: FT.ceilLog10Of1DividedByX(timeIntrospection.ComponentInfo.PAR_Interval.Validation.Data[2]);
                     }
                     // we have to override doApplyInput because integration time displays
                     // first entity's value but hast to change all in our list
@@ -128,7 +129,7 @@ Column {
                         id: validatorPeriod
                         bottom: periodIntrospection.ComponentInfo.PAR_Interval.Validation.Data[0];
                         top: periodIntrospection.ComponentInfo.PAR_Interval.Validation.Data[1];
-                        decimals: GC.ceilLog10Of1DividedByX(periodIntrospection.ComponentInfo.PAR_Interval.Validation.Data[2]);
+                        decimals: FT.ceilLog10Of1DividedByX(periodIntrospection.ComponentInfo.PAR_Interval.Validation.Data[2]);
                     }
                     // we have to override doApplyInput because integration period displays
                     // first entity's value but hast to change all in our list

--- a/qml/pages/ActualValuesPage.qml
+++ b/qml/pages/ActualValuesPage.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.0
 import QtQuick.Controls.Material 2.0
 import VeinEntity 1.0
 import GlobalConfig 1.0
+import FunctionTools 1.0
 import ZeraGlueLogic 1.0
 import ZeraTranslation  1.0
 import "qrc:/qml/controls" as CCMP
@@ -38,28 +39,28 @@ CCMP.ModulePage {
             width: root.columnWidth
             height: root.rowHeight
             color: index === 0 ? GC.tableShadeColor : Material.backgroundColor
-            text: L1!==undefined ? GC.formatNumber(L1) : ""
+            text: L1!==undefined ? FT.formatNumber(L1) : ""
             textColor: isCurrent ? GC.colorIL1 : GC.colorUL1
           }
           CCMP.GridItem {
             width: root.columnWidth
             height: root.rowHeight
             color: index === 0 ? GC.tableShadeColor : Material.backgroundColor
-            text: L2!==undefined ? GC.formatNumber(L2) : ""
+            text: L2!==undefined ? FT.formatNumber(L2) : ""
             textColor: isCurrent ? GC.colorIL2 : GC.colorUL2
           }
           CCMP.GridItem {
             width: root.columnWidth
             height: root.rowHeight
             color: index === 0 ? GC.tableShadeColor : Material.backgroundColor
-            text: L3!==undefined ? GC.formatNumber(L3) : ""
+            text: L3!==undefined ? FT.formatNumber(L3) : ""
             textColor: isCurrent ? GC.colorIL3 : GC.colorUL3
           }
           CCMP.GridItem {
             width: root.columnWidth
             height: root.rowHeight
             color: index === 0 ? GC.tableShadeColor : Material.backgroundColor
-            text: Sum ? GC.formatNumber(Sum) : ""
+            text: Sum ? FT.formatNumber(Sum) : ""
           }
           CCMP.GridItem {
             width: root.columnWidth/2

--- a/qml/pages/BurdenModulePage.qml
+++ b/qml/pages/BurdenModulePage.qml
@@ -4,6 +4,7 @@ import QtQuick.Controls.Material 2.0
 import QtQuick.Layouts 1.0
 import VeinEntity 1.0
 import GlobalConfig 1.0
+import FunctionTools 1.0
 import ZeraGlueLogic 1.0
 import ZeraTranslation  1.0
 import ModuleIntrospection 1.0
@@ -92,7 +93,7 @@ Item {
                             width: page.columnWidth
                             height: page.rowHeight
                             color: index === 0 ? GC.tableShadeColor : Material.backgroundColor
-                            text: L1!==undefined ? GC.formatNumber(L1) : ""
+                            text: L1!==undefined ? FT.formatNumber(L1) : ""
                             textColor: isVoltagePage ? GC.colorUL1 : GC.colorIL1
                             font.bold: index === 0
                         }
@@ -100,7 +101,7 @@ Item {
                             width: page.columnWidth
                             height: page.rowHeight
                             color: index === 0 ? GC.tableShadeColor : Material.backgroundColor
-                            text: L2!==undefined ? GC.formatNumber(L2) : ""
+                            text: L2!==undefined ? FT.formatNumber(L2) : ""
                             textColor: isVoltagePage ? GC.colorUL2 : GC.colorIL2
                             font.bold: index === 0
                         }
@@ -108,7 +109,7 @@ Item {
                             width: page.columnWidth
                             height: page.rowHeight
                             color: index === 0 ? GC.tableShadeColor : Material.backgroundColor
-                            text: L3!==undefined ? GC.formatNumber(L3) : ""
+                            text: L3!==undefined ? FT.formatNumber(L3) : ""
                             textColor: isVoltagePage ? GC.colorUL3 : GC.colorIL3
                             font.bold: index === 0
                         }
@@ -145,7 +146,7 @@ Item {
                         validator: ZDoubleValidator {
                             bottom: burdenIntrospection.ComponentInfo[parNominalBurden.controlPropertyName].Validation.Data[0];
                             top: burdenIntrospection.ComponentInfo[parNominalBurden.controlPropertyName].Validation.Data[1];
-                            decimals: GC.ceilLog10Of1DividedByX(burdenIntrospection.ComponentInfo[parNominalBurden.controlPropertyName].Validation.Data[2]);
+                            decimals: FT.ceilLog10Of1DividedByX(burdenIntrospection.ComponentInfo[parNominalBurden.controlPropertyName].Validation.Data[2]);
                         }
                     }
                     VFLineEdit {
@@ -163,7 +164,7 @@ Item {
                         validator: ZDoubleValidator {
                             bottom: burdenIntrospection.ComponentInfo[parNominalRange.controlPropertyName].Validation.Data[0];
                             top: burdenIntrospection.ComponentInfo[parNominalRange.controlPropertyName].Validation.Data[1];
-                            decimals: GC.ceilLog10Of1DividedByX(burdenIntrospection.ComponentInfo[parNominalRange.controlPropertyName].Validation.Data[2]);
+                            decimals: FT.ceilLog10Of1DividedByX(burdenIntrospection.ComponentInfo[parNominalRange.controlPropertyName].Validation.Data[2]);
                         }
                         ZVisualComboBox {
                             anchors.left: parent.right
@@ -206,7 +207,7 @@ Item {
                         validator: ZDoubleValidator {
                             bottom: burdenIntrospection.ComponentInfo[parWCrosssection.controlPropertyName].Validation.Data[0];
                             top: burdenIntrospection.ComponentInfo[parWCrosssection.controlPropertyName].Validation.Data[1];
-                            decimals: GC.ceilLog10Of1DividedByX(burdenIntrospection.ComponentInfo[parWCrosssection.controlPropertyName].Validation.Data[2]);
+                            decimals: FT.ceilLog10Of1DividedByX(burdenIntrospection.ComponentInfo[parWCrosssection.controlPropertyName].Validation.Data[2]);
                         }
                     }
                     VFLineEdit {
@@ -224,7 +225,7 @@ Item {
                         validator: ZDoubleValidator {
                             bottom: burdenIntrospection.ComponentInfo[parWireLength.controlPropertyName].Validation.Data[0];
                             top: burdenIntrospection.ComponentInfo[parWireLength.controlPropertyName].Validation.Data[1];
-                            decimals: GC.ceilLog10Of1DividedByX(burdenIntrospection.ComponentInfo[parWireLength.controlPropertyName].Validation.Data[2]);
+                            decimals: FT.ceilLog10Of1DividedByX(burdenIntrospection.ComponentInfo[parWireLength.controlPropertyName].Validation.Data[2]);
                         }
                     }
                 }

--- a/qml/pages/CEDModulePage.qml
+++ b/qml/pages/CEDModulePage.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.0
 import QtQuick.Controls.Material 2.0
 import VeinEntity 1.0
 import GlobalConfig 1.0
+import FunctionTools 1.0
 import ZeraTranslation  1.0
 import ModuleIntrospection 1.0
 import "qrc:/qml/controls" as CCMP
@@ -146,7 +147,7 @@ CCMP.ModulePage {
                         width: columnWidth
                         height: rowHeight
                         textColor: GC.colorUL1
-                        text: GC.formatNumber(power2Module1[String(ced_root.getProperty(index)).arg(1)]);
+                        text: FT.formatNumber(power2Module1[String(ced_root.getProperty(index)).arg(1)]);
                         font.pixelSize: pixelSize
                     }
                     CCMP.GridItem {
@@ -154,7 +155,7 @@ CCMP.ModulePage {
                         width: columnWidth
                         height: rowHeight
                         textColor: GC.colorUL2
-                        text: GC.formatNumber(power2Module1[String(ced_root.getProperty(index)).arg(2)]);
+                        text: FT.formatNumber(power2Module1[String(ced_root.getProperty(index)).arg(2)]);
                         font.pixelSize: pixelSize
                     }
                     CCMP.GridItem {
@@ -162,14 +163,14 @@ CCMP.ModulePage {
                         width: columnWidth
                         height: rowHeight
                         textColor: GC.colorUL3
-                        text: GC.formatNumber(power2Module1[String(ced_root.getProperty(index)).arg(3)]);
+                        text: FT.formatNumber(power2Module1[String(ced_root.getProperty(index)).arg(3)]);
                         font.pixelSize: pixelSize
                     }
                     CCMP.GridItem {
                         //pSum
                         width: columnWidth
                         height: rowHeight
-                        text: GC.formatNumber(power2Module1[String(ced_root.getProperty(index)).arg(4)]);
+                        text: FT.formatNumber(power2Module1[String(ced_root.getProperty(index)).arg(4)]);
                         font.pixelSize: pixelSize
                     }
                     CCMP.GridItem {

--- a/qml/pages/ComparisonTabsView.qml
+++ b/qml/pages/ComparisonTabsView.qml
@@ -6,6 +6,7 @@ import ZeraTranslation  1.0
 import VeinEntity 1.0
 import ModuleIntrospection 1.0
 import GlobalConfig 1.0
+import FunctionTools 1.0
 
 Item {
     id: root
@@ -88,7 +89,7 @@ Item {
         ErrorRegisterModulePage {
             errCalEntity: VeinEntity.getEntity("SEM1Module1")
             moduleIntrospection: ModuleIntrospection.sem1Introspection
-            actualValue: GC.formatNumber(errCalEntity.ACT_Energy) + " " + moduleIntrospection.ComponentInfo.ACT_Energy.Unit
+            actualValue: FT.formatNumber(errCalEntity.ACT_Energy) + " " + moduleIntrospection.ComponentInfo.ACT_Energy.Unit
             SwipeView.onIsCurrentItemChanged: {
                 if(SwipeView.isCurrentItem) {
                     GC.currentGuiContext = GC.guiContextEnum.GUI_ENERGY_REGISTER
@@ -101,7 +102,7 @@ Item {
         ErrorRegisterModulePage {
             errCalEntity: VeinEntity.getEntity("SPM1Module1")
             moduleIntrospection: ModuleIntrospection.spm1Introspection
-            actualValue: GC.formatNumber(errCalEntity.ACT_Power) + " " + moduleIntrospection.ComponentInfo.ACT_Power.Unit
+            actualValue: FT.formatNumber(errCalEntity.ACT_Power) + " " + moduleIntrospection.ComponentInfo.ACT_Power.Unit
             SwipeView.onIsCurrentItemChanged: {
                 if(SwipeView.isCurrentItem) {
                     GC.currentGuiContext = GC.guiContextEnum.GUI_POWER_REGISTER

--- a/qml/pages/ErrorCalculatorModulePage.qml
+++ b/qml/pages/ErrorCalculatorModulePage.qml
@@ -5,6 +5,7 @@ import QtQuick.Controls.Material 2.0
 import VeinEntity 1.0
 import ZeraTranslation  1.0
 import GlobalConfig 1.0
+import FunctionTools 1.0
 import ModuleIntrospection 1.0
 import ZeraVeinComponents 1.0
 import ZeraFa 1.0
@@ -71,10 +72,10 @@ CCMP.ModulePage {
             onProgressChanged: updateProgess()
             progressTo: 100
             readonly property real currEnergy: errCalEntity.PAR_Continuous === 1 ? errCalEntity.ACT_EnergyFinal : errCalEntity.ACT_Energy
-            readonly property var scaledEnergyArr: GC.doAutoScale(currEnergy, moduleIntrospection.ComponentInfo.ACT_Energy.Unit)
+            readonly property var scaledEnergyArr: FT.doAutoScale(currEnergy, moduleIntrospection.ComponentInfo.ACT_Energy.Unit)
             readonly property int measNum: errCalEntity.ACT_MeasNum
             onMeasNumChanged: updateProgess() // for fast measurements
-            actualValue: GC.formatNumber(scaledEnergyArr[0]) + " " + scaledEnergyArr[1]
+            actualValue: FT.formatNumber(scaledEnergyArr[0]) + " " + scaledEnergyArr[1]
         }
         Row {
             height: root.height*0.7

--- a/qml/pages/OsciModulePage.qml
+++ b/qml/pages/OsciModulePage.qml
@@ -6,6 +6,7 @@ import QtQuick.Controls.Material 2.0
 import ModuleIntrospection 1.0
 import VeinEntity 1.0
 import GlobalConfig 1.0
+import FunctionTools 1.0
 import ZeraGlueLogic 1.0
 import ZeraLocale 1.0
 import "qrc:/qml/controls" as CCMP
@@ -84,14 +85,14 @@ Item {
                 anchors.left: parent.left
                 rotation: -90
                 text: ModuleIntrospection.osciIntrospection.ComponentInfo["ACT_OSCI"+(leftChannels[index]+1)].ChannelName;
-                color: GC.getColorByIndex(leftChannels[index]+1);
+                color: FT.getColorByIndex(leftChannels[index]+1);
             }
             Label {
                 anchors.verticalCenter: parent.verticalCenter
                 anchors.right: parent.right
                 rotation: 90
                 text: ModuleIntrospection.osciIntrospection.ComponentInfo["ACT_OSCI"+(rightChannels[index]+1)].ChannelName;
-                color: GC.getColorByIndex(rightChannels[index]+1);
+                color: FT.getColorByIndex(rightChannels[index]+1);
             }
             ChartView {
                 anchors.left: parent.left
@@ -133,8 +134,8 @@ Item {
 
                     minorGridLineColor: Material.dividerColor
                     gridLineColor: Material.frameColor
-                    labelsColor: GC.getColorByIndex(leftChannels[index]+1)
-                    color: GC.getColorByIndex(leftChannels[index]+1)
+                    labelsColor: FT.getColorByIndex(leftChannels[index]+1)
+                    color: FT.getColorByIndex(leftChannels[index]+1)
                 }
                 ValueAxis {
                     id: yAxisRight
@@ -148,15 +149,15 @@ Item {
 
                     minorGridLineColor: Material.dividerColor
                     gridLineColor: Material.frameColor
-                    labelsColor: GC.getColorByIndex(rightChannels[index]+1)
-                    color: GC.getColorByIndex(rightChannels[index]+1)
+                    labelsColor: FT.getColorByIndex(rightChannels[index]+1)
+                    color: FT.getColorByIndex(rightChannels[index]+1)
                 }
 
                 LineSeries {
                     id: leftSeries
                     axisX: xAxis
                     axisY: yAxisLeft
-                    color: GC.getColorByIndex(leftChannels[index]+1);
+                    color: FT.getColorByIndex(leftChannels[index]+1);
                     width: 2
                     useOpenGL: true
                 }
@@ -165,7 +166,7 @@ Item {
                     id: rightSeries
                     axisX: xAxis
                     axisYRight: yAxisRight
-                    color: GC.getColorByIndex(rightChannels[index]+1);
+                    color: FT.getColorByIndex(rightChannels[index]+1);
                     width: 2
                     useOpenGL: true
                 }

--- a/qml/pages/PowerModulePage.qml
+++ b/qml/pages/PowerModulePage.qml
@@ -4,6 +4,7 @@ import QtQuick.Controls.Material 2.0
 import VeinEntity 1.0
 import ZeraTranslation  1.0
 import GlobalConfig 1.0
+import FunctionTools 1.0
 import ModuleIntrospection 1.0
 import ZeraVeinComponents 1.0
 import "qrc:/qml/controls" as CCMP
@@ -132,7 +133,7 @@ CCMP.ModulePage {
                     width: valueColumnWidth
                     height: parent.height
                     clip: true
-                    text: GC.formatNumber(root.getModule(index).ACT_PQS1);
+                    text: FT.formatNumber(root.getModule(index).ACT_PQS1);
                     textColor: GC.colorUL1
                     font.pixelSize: height*0.4
                 }
@@ -140,7 +141,7 @@ CCMP.ModulePage {
                     width: valueColumnWidth
                     height: parent.height
                     clip: true
-                    text: GC.formatNumber(root.getModule(index).ACT_PQS2);
+                    text: FT.formatNumber(root.getModule(index).ACT_PQS2);
                     textColor: GC.colorUL2
                     font.pixelSize: height*0.4
                 }
@@ -148,7 +149,7 @@ CCMP.ModulePage {
                     width: valueColumnWidth
                     height: parent.height
                     clip: true
-                    text: GC.formatNumber(root.getModule(index).ACT_PQS3);
+                    text: FT.formatNumber(root.getModule(index).ACT_PQS3);
                     textColor: GC.colorUL3
                     font.pixelSize: height*0.4
                 }
@@ -156,7 +157,7 @@ CCMP.ModulePage {
                     width: valueColumnWidth
                     height: parent.height
                     clip: true
-                    text: GC.formatNumber(root.getModule(index).ACT_PQS4);
+                    text: FT.formatNumber(root.getModule(index).ACT_PQS4);
                     font.pixelSize: height*0.4
                 }
                 CCMP.GridItem {

--- a/qml/pages/RMS4PhasePage.qml
+++ b/qml/pages/RMS4PhasePage.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.0
 import QtQuick.Controls.Material 2.0
 import VeinEntity 1.0
 import GlobalConfig 1.0
+import FunctionTools 1.0
 import ZeraGlueLogic 1.0
 import SortFilterProxyModel 0.2
 import ModuleIntrospection 1.0
@@ -56,7 +57,7 @@ CCMP.ModulePage {
             width: root.columnWidth
             height: parent.height
             color: index === 0 ? GC.tableShadeColor : Material.backgroundColor
-            text: L1!==undefined ? GC.formatNumber(L1) : ""
+            text: L1!==undefined ? FT.formatNumber(L1) : ""
             textColor: isCurrent ? GC.colorIL1 : GC.colorUL1
             font.pixelSize: root.pixelSize
           }
@@ -64,7 +65,7 @@ CCMP.ModulePage {
             width: root.columnWidth
             height: parent.height
             color: index === 0 ? GC.tableShadeColor : Material.backgroundColor
-            text: L2!==undefined ? GC.formatNumber(L2) : ""
+            text: L2!==undefined ? FT.formatNumber(L2) : ""
             textColor: isCurrent ? GC.colorIL2 : GC.colorUL2
             font.pixelSize: root.pixelSize
           }
@@ -72,7 +73,7 @@ CCMP.ModulePage {
             width: root.columnWidth
             height: parent.height
             color: index === 0 ? GC.tableShadeColor : Material.backgroundColor
-            text: L3!==undefined ? GC.formatNumber(L3) : ""
+            text: L3!==undefined ? FT.formatNumber(L3) : ""
             textColor: isCurrent ? GC.colorIL3 : GC.colorUL3
             font.pixelSize: root.pixelSize
           }
@@ -80,7 +81,7 @@ CCMP.ModulePage {
             width: root.columnWidth
             height: parent.height
             color: index === 0 ? GC.tableShadeColor : Material.backgroundColor
-            text: AUX!==undefined ? GC.formatNumber(AUX) : ""
+            text: AUX!==undefined ? FT.formatNumber(AUX) : ""
             textColor: isCurrent ? GC.colorIAux1 : GC.colorUAux1
             font.pixelSize: root.pixelSize
             visible: channelCount > 6

--- a/qml/pages/RefModulePage.qml
+++ b/qml/pages/RefModulePage.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.0
 import QtQuick.Controls.Material 2.0
 import VeinEntity 1.0
 import GlobalConfig 1.0
+import FunctionTools 1.0
 import ZeraTranslation  1.0
 import "qrc:/qml/controls" as CCMP
 
@@ -101,7 +102,7 @@ CCMP.ModulePage {
                     width: wideRowWidth
                     height: root.rowHeight
                     clip: true
-                    text: GC.formatNumber(dftModule.ACT_DFTPN1[0], 6); //these values are RE,IM vectors of a measured DC quantity, so only the RE part is relevant
+                    text: FT.formatNumber(dftModule.ACT_DFTPN1[0], 6); //these values are RE,IM vectors of a measured DC quantity, so only the RE part is relevant
                     textColor: GC.groupColorReference
                     font.pixelSize: height*0.3
                 }
@@ -109,7 +110,7 @@ CCMP.ModulePage {
                     width: wideRowWidth
                     height: root.rowHeight
                     clip: true
-                    text: GC.formatNumber(dftModule.ACT_DFTPN2[0], 6); //these values are RE,IM vectors of a measured DC quantity, so only the RE part is relevant
+                    text: FT.formatNumber(dftModule.ACT_DFTPN2[0], 6); //these values are RE,IM vectors of a measured DC quantity, so only the RE part is relevant
                     textColor: GC.groupColorReference
                     font.pixelSize: height*0.3
                 }
@@ -117,7 +118,7 @@ CCMP.ModulePage {
                     width: wideRowWidth
                     height: root.rowHeight
                     clip: true
-                    text: GC.formatNumber(dftModule.ACT_DFTPN3[0], 6); //these values are RE,IM vectors of a measured DC quantity, so only the RE part is relevant
+                    text: FT.formatNumber(dftModule.ACT_DFTPN3[0], 6); //these values are RE,IM vectors of a measured DC quantity, so only the RE part is relevant
                     textColor: GC.groupColorReference
                     font.pixelSize: height*0.3
                 }
@@ -125,7 +126,7 @@ CCMP.ModulePage {
                     width: wideRowWidth
                     height: root.rowHeight
                     clip: true
-                    text: GC.formatNumber(dftModule.ACT_DFTPN4[0], 6); //these values are RE,IM vectors of a measured DC quantity, so only the RE part is relevant
+                    text: FT.formatNumber(dftModule.ACT_DFTPN4[0], 6); //these values are RE,IM vectors of a measured DC quantity, so only the RE part is relevant
                     textColor: GC.groupColorReference
                     font.pixelSize: height*0.3
                 }
@@ -133,7 +134,7 @@ CCMP.ModulePage {
                     width: wideRowWidth
                     height: root.rowHeight
                     clip: true
-                    text: GC.formatNumber(dftModule.ACT_DFTPN5[0], 6); //these values are RE,IM vectors of a measured DC quantity, so only the RE part is relevant
+                    text: FT.formatNumber(dftModule.ACT_DFTPN5[0], 6); //these values are RE,IM vectors of a measured DC quantity, so only the RE part is relevant
                     textColor: GC.groupColorReference
                     font.pixelSize: height*0.3
                 }
@@ -141,7 +142,7 @@ CCMP.ModulePage {
                     width: wideRowWidth
                     height: root.rowHeight
                     clip: true
-                    text: GC.formatNumber(dftModule.ACT_DFTPN6[0], 6); //these values are RE,IM vectors of a measured DC quantity, so only the RE part is relevant
+                    text: FT.formatNumber(dftModule.ACT_DFTPN6[0], 6); //these values are RE,IM vectors of a measured DC quantity, so only the RE part is relevant
                     textColor: GC.groupColorReference
                     font.pixelSize: height*0.3
                 }

--- a/qml/pages/TransformerModulePage.qml
+++ b/qml/pages/TransformerModulePage.qml
@@ -4,6 +4,7 @@ import QtQuick.Controls.Material 2.0
 import QtQuick.Layouts 1.0
 import VeinEntity 1.0
 import GlobalConfig 1.0
+import FunctionTools 1.0
 import ZeraGlueLogic 1.0
 import ZeraTranslation  1.0
 import ModuleIntrospection 1.0
@@ -70,7 +71,7 @@ CCMP.ModulePage {
             CCMP.GridItem {
                 width: root.width*0.6
                 height: root.rowHeight
-                text: GC.formatNumber(transformerModule.ACT_IXPrimary1)
+                text: FT.formatNumber(transformerModule.ACT_IXPrimary1)
             }
             CCMP.GridItem {
                 width: root.width*0.2
@@ -91,7 +92,7 @@ CCMP.ModulePage {
             CCMP.GridItem {
                 width: root.width*0.6
                 height: root.rowHeight
-                text: GC.formatNumber(transformerModule.ACT_INSecondary1)
+                text: FT.formatNumber(transformerModule.ACT_INSecondary1)
             }
             CCMP.GridItem {
                 width: root.width*0.2
@@ -112,7 +113,7 @@ CCMP.ModulePage {
             CCMP.GridItem {
                 width: root.width*0.6
                 height: root.rowHeight
-                text: GC.formatNumber(transformerModule.ACT_IXSecondary1)
+                text: FT.formatNumber(transformerModule.ACT_IXSecondary1)
             }
             CCMP.GridItem {
                 width: root.width*0.2
@@ -133,7 +134,7 @@ CCMP.ModulePage {
             CCMP.GridItem {
                 width: root.width*0.6
                 height: root.rowHeight
-                text: GC.formatNumber(transformerModule.ACT_Ratio1)
+                text: FT.formatNumber(transformerModule.ACT_Ratio1)
             }
             CCMP.GridRect {
                 width: root.width*0.2
@@ -153,7 +154,7 @@ CCMP.ModulePage {
             CCMP.GridItem {
                 width: root.width*0.6
                 height: root.rowHeight
-                text: GC.formatNumber(transformerModule.ACT_Error1)
+                text: FT.formatNumber(transformerModule.ACT_Error1)
             }
             CCMP.GridItem {
                 width: root.width*0.2
@@ -174,7 +175,7 @@ CCMP.ModulePage {
             CCMP.GridItem {
                 width: root.width*0.6
                 height: root.rowHeight
-                text: GC.formatNumber(transformerModule.ACT_Angle1)
+                text: FT.formatNumber(transformerModule.ACT_Angle1)
             }
             CCMP.GridItem {
                 width: root.width*0.2
@@ -195,7 +196,7 @@ CCMP.ModulePage {
             CCMP.GridItem {
                 width: root.width*0.6
                 height: root.rowHeight
-                text: GC.formatNumber(100 * transformerModule.ACT_Angle1 * Math.PI/180)
+                text: FT.formatNumber(100 * transformerModule.ACT_Angle1 * Math.PI/180)
             }
             CCMP.GridItem {
                 width: root.width*0.2
@@ -216,7 +217,7 @@ CCMP.ModulePage {
             CCMP.GridItem {
                 width: root.width*0.6
                 height: root.rowHeight
-                text: GC.formatNumber(transformerModule.ACT_Angle1*60)
+                text: FT.formatNumber(transformerModule.ACT_Angle1*60)
             }
             CCMP.GridItem {
                 width: root.width*0.2
@@ -251,7 +252,7 @@ CCMP.ModulePage {
                     validator: ZDoubleValidator {
                         bottom: transformerIntrospection.ComponentInfo[parPrimClampPrim.controlPropertyName].Validation.Data[0];
                         top: transformerIntrospection.ComponentInfo[parPrimClampPrim.controlPropertyName].Validation.Data[1];
-                        decimals: GC.ceilLog10Of1DividedByX(transformerIntrospection.ComponentInfo[parPrimClampPrim.controlPropertyName].Validation.Data[2]);
+                        decimals: FT.ceilLog10Of1DividedByX(transformerIntrospection.ComponentInfo[parPrimClampPrim.controlPropertyName].Validation.Data[2]);
                     }
                 }
                 VFLineEdit {
@@ -269,7 +270,7 @@ CCMP.ModulePage {
                     validator: ZDoubleValidator {
                         bottom: transformerIntrospection.ComponentInfo[parPrimClampSec.controlPropertyName].Validation.Data[0];
                         top: transformerIntrospection.ComponentInfo[parPrimClampSec.controlPropertyName].Validation.Data[1];
-                        decimals:  GC.ceilLog10Of1DividedByX(transformerIntrospection.ComponentInfo[parPrimClampSec.controlPropertyName].Validation.Data[2]);
+                        decimals:  FT.ceilLog10Of1DividedByX(transformerIntrospection.ComponentInfo[parPrimClampSec.controlPropertyName].Validation.Data[2]);
                     }
                 }
             }
@@ -291,7 +292,7 @@ CCMP.ModulePage {
                     validator: ZDoubleValidator {
                         bottom: transformerIntrospection.ComponentInfo[parDutPrimary.controlPropertyName].Validation.Data[0];
                         top: transformerIntrospection.ComponentInfo[parDutPrimary.controlPropertyName].Validation.Data[1];
-                        decimals: GC.ceilLog10Of1DividedByX(transformerIntrospection.ComponentInfo[parDutPrimary.controlPropertyName].Validation.Data[2]);
+                        decimals: FT.ceilLog10Of1DividedByX(transformerIntrospection.ComponentInfo[parDutPrimary.controlPropertyName].Validation.Data[2]);
                     }
                 }
                 VFLineEdit {
@@ -309,7 +310,7 @@ CCMP.ModulePage {
                     validator: ZDoubleValidator {
                         bottom: transformerIntrospection.ComponentInfo[parDutSecondary.controlPropertyName].Validation.Data[0];
                         top: transformerIntrospection.ComponentInfo[parDutSecondary.controlPropertyName].Validation.Data[1];
-                        decimals: GC.ceilLog10Of1DividedByX(transformerIntrospection.ComponentInfo[parDutSecondary.controlPropertyName].Validation.Data[2]);
+                        decimals: FT.ceilLog10Of1DividedByX(transformerIntrospection.ComponentInfo[parDutSecondary.controlPropertyName].Validation.Data[2]);
                     }
                 }
             }
@@ -331,7 +332,7 @@ CCMP.ModulePage {
                     validator: ZDoubleValidator {
                         bottom: transformerIntrospection.ComponentInfo[parSecClampPrim.controlPropertyName].Validation.Data[0];
                         top: transformerIntrospection.ComponentInfo[parSecClampPrim.controlPropertyName].Validation.Data[1];
-                        decimals:  GC.ceilLog10Of1DividedByX(transformerIntrospection.ComponentInfo[parSecClampPrim.controlPropertyName].Validation.Data[2]);
+                        decimals:  FT.ceilLog10Of1DividedByX(transformerIntrospection.ComponentInfo[parSecClampPrim.controlPropertyName].Validation.Data[2]);
                     }
                 }
                 VFLineEdit {
@@ -349,7 +350,7 @@ CCMP.ModulePage {
                     validator: ZDoubleValidator {
                         bottom: transformerIntrospection.ComponentInfo[parSecClampSec.controlPropertyName].Validation.Data[0];
                         top: transformerIntrospection.ComponentInfo[parSecClampSec.controlPropertyName].Validation.Data[1];
-                        decimals: GC.ceilLog10Of1DividedByX(transformerIntrospection.ComponentInfo[parSecClampSec.controlPropertyName].Validation.Data[2]);
+                        decimals: FT.ceilLog10Of1DividedByX(transformerIntrospection.ComponentInfo[parSecClampSec.controlPropertyName].Validation.Data[2]);
                     }
                 }
             }

--- a/qml/pages/VectorModulePage.qml
+++ b/qml/pages/VectorModulePage.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.0
 import VeinEntity 1.0
 import QtQuick.Controls.Material 2.0
 import GlobalConfig 1.0
+import FunctionTools 1.0
 import ModuleIntrospection 1.0
 import uivectorgraphics 1.0
 import ZeraComponents 1.0
@@ -140,8 +141,8 @@ CCMP.ModulePage {
                 maxVoltage *= Math.sqrt(3)
             }
             // factor 1000: Our auto scale scales too late - it was designed for values rising monotonous
-            let valUnitArr = GC.doAutoScale(maxVoltage / (1000*maxNominalFactor * Math.sqrt(2)), "V")
-            return GC.formatNumber(valUnitArr[0]*1000, lenMode.rangeLen ? 0 : undefined) + valUnitArr[1]
+            let valUnitArr = FT.doAutoScale(maxVoltage / (1000*maxNominalFactor * Math.sqrt(2)), "V")
+            return FT.formatNumber(valUnitArr[0]*1000, lenMode.rangeLen ? 0 : undefined) + valUnitArr[1]
         }
         text: "<font color='" + GC.groupColorVoltage + "'>"+ "U: " + valueStr + " * √2" + "</font>"
         anchors.bottom: currentIndicator.top
@@ -157,8 +158,8 @@ CCMP.ModulePage {
                 return maxIRange
             }
             // factor 1000: Our auto scale scales too late - it was designed for values rising monotonous
-            let valUnitArr = GC.doAutoScale(phasorDiagramm.maxCurrent / (1000 * maxNominalFactor * Math.sqrt(2)), "A")
-            return GC.formatNumber(valUnitArr[0]*1000, lenMode.rangeLen ? 0 : undefined) + valUnitArr[1]
+            let valUnitArr = FT.doAutoScale(phasorDiagramm.maxCurrent / (1000 * maxNominalFactor * Math.sqrt(2)), "A")
+            return FT.formatNumber(valUnitArr[0]*1000, lenMode.rangeLen ? 0 : undefined) + valUnitArr[1]
         }
         text: "<font color='" + GC.groupColorCurrent + "'>"+ "I: " + valueStr + " * √2" + "</font>"
         anchors.bottom: root.bottom;

--- a/qml/singletons/FunctionTools.qml
+++ b/qml/singletons/FunctionTools.qml
@@ -1,0 +1,227 @@
+pragma Singleton
+import QtQuick 2.0
+import ModuleIntrospection 1.0
+import GlobalConfig 1.0
+import ZeraLocale 1.0
+
+Item {
+    /////////////////////////////////////////////////////////////////////////////
+    // Color helper function
+    function getColorByIndex(rangIndex, grouping) {
+        var retVal;
+        if(grouping) {
+            var channelName = ModuleIntrospection.rangeIntrospection.ComponentInfo["PAR_Channel"+rangIndex+"Range"].ChannelName;
+            var group1 = ModuleIntrospection.rangeIntrospection.ModuleInfo.ChannelGroup1;
+            var group2 = ModuleIntrospection.rangeIntrospection.ModuleInfo.ChannelGroup2;
+            var group3 = ModuleIntrospection.rangeIntrospection.ModuleInfo.ChannelGroup3;
+
+            if(group1 !== undefined && group1.indexOf(channelName)>-1) {
+                retVal = GC.groupColorVoltage
+            }
+            else if(group2 !== undefined && group2.indexOf(channelName)>-1) {
+                retVal = GC.groupColorCurrent
+            }
+            else if(group3 !== undefined && group3.indexOf(channelName)>-1) {
+                retVal = GC.groupColorReference
+            }
+            else { //index is not in group
+                retVal = GC.currentColorTable[rangIndex-1]
+            }
+        }
+        else {
+            retVal = GC.currentColorTable[rangIndex-1]
+        }
+        return retVal;
+    }
+
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Time helpers ms <-> string
+    function msToTime(t_mSeconds) {
+        if(t_mSeconds === undefined) {
+            t_mSeconds = 0
+        }
+        var ms = t_mSeconds % 1000
+        t_mSeconds = (t_mSeconds - ms) / 1000
+        var secs = t_mSeconds % 60;
+        t_mSeconds = (t_mSeconds - secs) / 60
+        var mins = t_mSeconds % 60;
+        var hours = (t_mSeconds - mins) / 60;
+        return ("0"+hours).slice(-2) + ':' + ("0"+mins).slice(-2) + ':' + ("0"+secs).slice(-2);// + '.' + ("00"+ms).slice(-3);
+    }
+    function timeToMs(t_time) {
+        var mSeconds = 0;
+        var timeData = [];
+
+        if((String(t_time).match(/:/g) || []).length === 2) {
+            timeData = t_time.split(':');
+            var hours = Number(timeData[0]);
+            mSeconds += hours * 3600000;
+            var minutes = Number(timeData[1]);
+            mSeconds += minutes * 60000;
+            var seconds = Number(timeData[2]);
+            mSeconds += seconds * 1000;
+        }
+        return Number(mSeconds);
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Auto scale helper functions
+    // Auto scale float value (num) / unit. Return value is an array [value,unit]
+    function doAutoScale(num, strUnit) {
+        // remove prefix (means calc base unit and value)
+        var baseUnitInfo = getExponentAndBaseUnitFromUnit(strUnit)
+        var baseValue = num * Math.pow(10, baseUnitInfo[0])
+        // calc scaled value and prefixed unit on base values
+        var autoScaleExponent = getAutoScaleExponent(baseValue)
+        var autoScalePrefix = getPrefixFromExponent(autoScaleExponent)
+        var autoScaleValue = baseValue * Math.pow(10, -autoScaleExponent)
+        var autoScaleUnit = autoScalePrefix+baseUnitInfo[1]
+        return [autoScaleValue, autoScaleUnit]
+    }
+
+    function getAutoScaleExponent(num) {
+        var floatVal = 0.0
+        if(typeof num === "string") {
+            floatVal = parseFloat(num)
+        }
+        else {
+            floatVal = num
+        }
+        floatVal = Math.abs(floatVal)
+        var exponent = 0
+        // a zero value does not get a prefix
+        if(floatVal < 1e-15*GC.autoScaleLimit) {
+            exponent = 0
+        }
+        else if(floatVal < 1e-12*GC.autoScaleLimit) {
+            exponent = -12
+        }
+        else if(floatVal < 1e-9*GC.autoScaleLimit) {
+            exponent = -9
+        }
+        else if(floatVal < 1e-6*GC.autoScaleLimit) {
+            exponent = -6
+        }
+        else if(floatVal < 1e-3*GC.autoScaleLimit) {
+            exponent = -3
+        }
+        else if(floatVal > 1e12*GC.autoScaleLimit) {
+            exponent = 12
+        }
+        else if(floatVal > 1e9*GC.autoScaleLimit) {
+            exponent = 9
+        }
+        else if(floatVal > 1e6*GC.autoScaleLimit) {
+            exponent = 6
+        }
+        else if(floatVal > 1e3*GC.autoScaleLimit) {
+            exponent = 3
+        }
+        return exponent
+    }
+
+    function getPrefixFromExponent(exponent) {
+        var str = ""
+        switch(exponent) {
+        case -12:
+            str="p"
+            break
+        case -9:
+            str="n"
+            break
+        case -6:
+            str="µ"
+            break
+        case -3:
+            str="m"
+            break
+        case 3:
+            str="k"
+            break
+        case 6:
+            str="M"
+            break
+        case 9:
+            str="G"
+            break
+        case 12:
+            str="T"
+            break
+        }
+        return str
+    }
+
+    function getExponentAndBaseUnitFromUnit(strUnit) {
+        var strPrefix = strUnit.substring(0,1)
+        var exponent = 0
+        switch(strPrefix) {
+        case "p":
+            exponent = -12
+            break
+        case "n":
+            exponent = -9
+            break
+        case "µ":
+            exponent = -6
+            break
+        case "m":
+            exponent = -3
+            break
+        case "k":
+            exponent = 3
+            break
+        case "M":
+            exponent = 6
+            break
+        case "G":
+            exponent = 9
+            break
+        case "T":
+            exponent = 12
+            break
+        }
+        var strNewUnit = exponent === 0 ? strUnit : strUnit.substring(1)
+        return [exponent, strNewUnit]
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Number <-> String conversion helpers
+    function ceilLog10Of1DividedByX(realNumberX) {
+        return Math.ceil(Math.log(1/realNumberX)/Math.LN10)
+    }
+
+    function removeDecimalGroupSeparators(strNum) {
+        // remove group separators (this is ugly but don't get documented examples to fly here...)
+        var groupSepChar = ZLocale.getDecimalPoint() === "," ? "." : ","
+        while(strNum.includes(groupSepChar)) {
+            strNum = strNum.replace(groupSepChar, "")
+        }
+        return strNum
+    }
+
+    function formatNumber(num, decimalPlacesSet /* optional!!! */) {
+        if(typeof num === "string") { //parsing strings as number is not desired
+            return num;
+        }
+        else {
+            var dec = (decimalPlacesSet !== undefined) ? decimalPlacesSet : GC.decimalPlaces
+            var leadDigits = Math.floor(Math.abs(num)).toString()
+            // leading zero is not a digit
+            if(leadDigits === '0') {
+                leadDigits  = ''
+            }
+            var preDecimals = leadDigits.length
+            if(dec + preDecimals > GC.digitsTotal) {
+                dec = GC.digitsTotal - preDecimals
+                if(dec < 0) {
+                    dec = 0
+                }
+            }
+            var strNum = Number(num).toLocaleString(ZLocale.getLocale(), 'f', dec)
+            strNum = removeDecimalGroupSeparators(strNum)
+            return strNum
+        }
+    }
+
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,6 +54,7 @@ int main(int argc, char *argv[])
     qmlRegisterSingletonType<GlueLogicPropertyMap>("ZeraGlueLogic", 1, 0, "ZGL", GlueLogicPropertyMap::getStaticInstance);
     qmlRegisterSingletonType(QUrl("qrc:/qml/singletons/ModuleIntrospection.qml"), "ModuleIntrospection", 1, 0, "ModuleIntrospection");
     qmlRegisterSingletonType(QUrl("qrc:/qml/singletons/GlobalConfig.qml"), "GlobalConfig", 1, 0, "GC");
+    qmlRegisterSingletonType(QUrl("qrc:/qml/singletons/FunctionTools.qml"), "FunctionTools", 1, 0, "FT");
 
     app.setWindowIcon(QIcon(":/data/staticdata/resources/appicon.png"));
 


### PR DESCRIPTION
* Make most getters properties instead of functions
* Move helper functions into FunctionTools.qml. In the long run we could
  move some to vf-qmllibs but due to broken debug I am not keen on
* Ensure that ALL settings.globalSettings.getOption are wrapped by properties
  to avoid cross property change update fire: settings-item has just one
  notification for all settings!
  This lifts user experience to the next level: Many delays are gone!

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>