### PR TITLE
WaitTransaction: Ensure fast errors/warnings are displayed

### DIFF
--- a/qml/controls/WaitTransaction.qml
+++ b/qml/controls/WaitTransaction.qml
@@ -17,9 +17,6 @@ Popup {
         longRunAnimationSTartTimer.start()
     }
     function stopWait(warningTxtArr, errorTxtArr, fpOnFinish /* function pointer on finish */) {
-        if(!root.opened) {
-            return
-        }
         root.warningTxtArr = warningTxtArr
         root.errorTxtArr = errorTxtArr
         root.fpOnFinish = fpOnFinish


### PR DESCRIPTION
The assumption that Popup.open() sets Popup.opened immediately is incorrect. So
aborting further activities in stopWait if popup is not open leads to a wait
forever.
Intention of this check was to avoid effects in case stopWait is called without
calling startWait before. Even if this happens: There is not damage to expect
so skip this test.

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>