### PR TITLE
 Fix connection syntax warnings on Qt5.15

### DIFF
--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -110,7 +110,7 @@ ApplicationWindow {
 
     Connections {
         target: VeinEntity
-        onStateChanged: {
+        function onSigStateChanged(t_state) {
             if(t_state === VeinEntity.VQ_LOADED) {
                 dynamicPageModel.initModel();
                 pageView.model = dynamicPageModel;
@@ -142,7 +142,7 @@ ApplicationWindow {
             }
         }
 
-        onSigEntityAvailable: {
+        function onSigEntityAvailable(t_entityName) {
             var checkRequired = false;
             var entId = VeinEntity.getEntity(t_entityName).entityId()
             if(entId === 0) {

--- a/qml/controls/PageView.qml
+++ b/qml/controls/PageView.qml
@@ -168,7 +168,7 @@ Item {
 
             Connections {
                 target: VeinEntity
-                onSigEntityAvailable: {
+                function onSigEntityAvailable(t_entityName) {
                     if(t_entityName === "_System") {
                         sessionSelector.systemEntity = VeinEntity.getEntity("_System");
                     }


### PR DESCRIPTION
| QML Connections: Implicitly defined onFoo properties in Connections are deprecated. Use this syntax instead: function onFoo(<arguments>) { ... }

* Tested on Qt5.14 target machin
* They are right it reads much better and syntax highlight works
* VERY INTERESTING: The is no signal stateChanged. How could this ever work??

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>