### PR TITLE
Load "settings.json" from correct source path

### DIFF
--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -136,7 +136,7 @@ ApplicationWindow {
                 if(lastPageSelected >= pageView.model.count) {
                     lastPageSelected = 0
                 }
-                if(pageView.model.length) {
+                if(pageView.model.count) {
                     pageView.pageLoaderSource = pageView.model.get(lastPageSelected).elementValue;
                 }
                 loadingScreen.close();

--- a/qml/controls/PageView.qml
+++ b/qml/controls/PageView.qml
@@ -119,8 +119,8 @@ Item {
 
             property QtObject systemEntity;
             property string intermediate
-            property var arrDisplayStrings: [Z.tr("Default"), Z.tr("Changing energy direction"), Z.tr("Reference"), Z.tr("DC (experimental)")]
-            property var arrJSONDetectStrings: ["meas-session.json", "ced-session.json", "ref-session.json", "dc-session.json"]
+            property var arrDisplayStrings: [Z.tr("Default"), Z.tr("Changing energy direction"), Z.tr("Reference"), Z.tr("DC (experimental)"), "EMOB AC/DC"]
+            property var arrJSONDetectStrings: ["meas-session.json", "ced-session.json", "ref-session.json", "dc-session.json", "emob-session.json"]
             property var arrJSONFileNames: []
 
             anchors.fill: parent

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -109,13 +109,8 @@ int main(int argc, char *argv[])
         if(!standardConfigDirectory.exists(standardPath)) {
             standardConfigDirectory.mkdir(standardPath);
         }
-#ifndef QT_DEBUG
         // copy from qrc to standard dir
         const QString source = QStringLiteral("://data/settings.json");
-#else
-        // debugging does not work for standard (localhost) so copy the file from application
-        const QString source = QString("%1/%2").arg(standardPath).arg(QStringLiteral("settings.json"));
-#endif
         if(QFile::copy(source, targetPath)) {
             qInfo("Deployed default settings file from: qrc://data/settings.json");
             QFile::setPermissions(targetPath, QFlags<QFile::Permission>(0x6644)); //like 644


### PR DESCRIPTION
Fixes initial crash on fresh development environment.

Signed-off-by: Anuja Mutalik <a.mutalik@zera.de>