### PR TITLE
GlobalConfig: Change default black brightness to maximum white value

### DIFF
--- a/qml/singletons/GlobalConfig.qml
+++ b/qml/singletons/GlobalConfig.qml
@@ -247,7 +247,7 @@ Item {
         currentBrightness = brightness
         settings.globalSettings.setOption("currentBrightness", brightness);
     }
-    readonly property real defaultBlackBrightness: 1
+    readonly property real defaultBlackBrightness: 35
     property real blackBrightness: parseFloat(settings.globalSettings.getOption("blackBrightness", defaultBlackBrightness))
     function setBlackBrigtness(brightness) {
         blackBrightness = brightness


### PR DESCRIPTION
Background: With EMOB we use 4th(aux) phase more frequently and default UAUX
color is black.

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>