### PR TITLE
Main.qml: fix MainToolBar inconsistency for multiple GUIs

### DIFF
--- a/app/qml/Main.qml
+++ b/app/qml/Main.qml
@@ -55,7 +55,15 @@ ApplicationWindow {
         });
     }
 
+    function prepareSessionChange() {
+        layoutStack.currentIndex=0;
+        controlsBar.rangeIndicatorDependenciesReady = false;
+        pageLoader.active = false;
+        GC.entityInitializationDone = false;
+    }
+
     onCurrentSessionChanged: {
+        prepareSessionChange();
         var availableEntityIds = VeinEntity.getEntity("_System")["Entities"];
 
         var oldIdList = VeinEntity.getEntityList();
@@ -477,10 +485,7 @@ ApplicationWindow {
             visible: controlsBar.pageViewVisible;
             onCloseView: controlsBar.pageViewVisible = false;
             onSessionChanged: {
-                layoutStack.currentIndex=0;
-                controlsBar.rangeIndicatorDependenciesReady = false;
-                pageLoader.active = false;
-                GC.entityInitializationDone = false;
+                prepareSessionChange();
                 loadingScreen.open();
             }
         }


### PR DESCRIPTION
When session changed on one GUI, the second GUI's mainToolBar was not up to date