### PR TITLE
FunctionTools.qml: Remove removeDecimalGroupSeparators function

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -34,7 +34,6 @@ jobs:
           cmake $GITHUB_WORKSPACE \
            -DCMAKE_PREFIX_PATH="$HOME/install/usr;/usr" \
            -DCMAKE_INSTALL_PREFIX:PATH="$HOME/install/usr" \
-           -DCMAKE_INSTALL_SYSCONFDIR="$HOME/install/etc" \
-           -DfirstBuild=ON
+           -DCMAKE_INSTALL_SYSCONFDIR="$HOME/install/etc"
           # compile / install
            make -j $(getconf _NPROCESSORS_ONLN)

--- a/app/qml/singletons/FunctionTools.qml
+++ b/app/qml/singletons/FunctionTools.qml
@@ -191,15 +191,6 @@ Item {
         return Math.ceil(Math.log(1/realNumberX)/Math.LN10)
     }
 
-    function removeDecimalGroupSeparators(strNum) {
-        // remove group separators (this is ugly but don't get documented examples to fly here...)
-        var groupSepChar = ZLocale.decimalPoint === "," ? "." : ","
-        while(strNum.includes(groupSepChar)) {
-            strNum = strNum.replace(groupSepChar, "")
-        }
-        return strNum
-    }
-
     function formatNumber(num, decimalPlacesSet /* optional!!! */) {
         if(typeof num === "string") { //parsing strings as number is not desired
             return num;
@@ -218,9 +209,7 @@ Item {
                     dec = 0
                 }
             }
-            var strNum = Number(num).toLocaleString(ZLocale.locale, 'f', dec)
-            strNum = removeDecimalGroupSeparators(strNum)
-            return strNum
+            return Number(num).toLocaleString(ZLocale.locale, 'f', dec)
         }
     }
     function formatNumberCLocale(num, decimalPlacesSet /* optional!!! */) {


### PR DESCRIPTION
We introduced auto scaling - or at places we still see decimal group separators we have to introduce auto scaling.