### PR TITLE
ParamViewComparison: Adjust width of popButton and autoDutButton

### DIFF
--- a/app/qml/controls/error_comparison_params/ParamViewComparison.qml
+++ b/app/qml/controls/error_comparison_params/ParamViewComparison.qml
@@ -178,7 +178,7 @@ Item {
                 anchors.verticalCenter: meterConstLabel.verticalCenter
                 font.pointSize: pointSize
                 anchors.rightMargin: 10
-                width: parent.width/10
+                width: parent.width/12
                 Material.foreground: {
                     if(logicalParent.errCalEntity["PAR_DutTypeMeasurePoint"] === "CsIsUs"){
                         return "white";
@@ -194,7 +194,7 @@ Item {
                 id: autoDutButton
                 text: FA.icon(FA.fa_play)
                 font.pointSize: pointSize
-                width: parent.width/10
+                width: parent.width/12
                 anchors.right: popButton.left
                 anchors.verticalCenter: meterConstLabel.verticalCenter
                 anchors.rightMargin: parent.width/240

--- a/app/qml/controls/error_comparison_params/ParamViewComparison.qml
+++ b/app/qml/controls/error_comparison_params/ParamViewComparison.qml
@@ -198,7 +198,7 @@ Item {
                 anchors.right: popButton.left
                 anchors.verticalCenter: meterConstLabel.verticalCenter
                 anchors.rightMargin: parent.width/240
-                enabled: true
+                enabled: (VeinEntity.getEntity("SEC1Module1").ACT_Energy !== 0)
                 visible: VeinEntity.getEntity("_System").DevMode
                 onPressed: {
                     VeinEntity.getEntity("SEC1Module1").PAR_DutConstantAuto = 1


### PR DESCRIPTION
When language is German, text 'Zählerkonstante' and buttons overlap