### PR TITLE
RangeLine.qml: Get more cooler on pixels

### DIFF
--- a/app/qml/controls/ranges/RangeLine.qml
+++ b/app/qml/controls/ranges/RangeLine.qml
@@ -18,7 +18,7 @@ ListView {
 
     readonly property real headerHeight: height * 0.2
     readonly property real comboHeight: height * 0.6
-    readonly property real vuHeight: height * 0.1
+    readonly property real vuHeight: height * 0.03
 
     delegate: Item {
         id: channelsRow


### PR DESCRIPTION
There are issues:
ATTOW vf-qmllib has this x/y thingy on vu nominal indicators. Go fix them and consider shapes suggested as target to support.