### PR TITLE
EMOBActualValuesPageDC: remove QML warning

### DIFF
--- a/app/qml/pages/EMOBActualValuesPageDC.qml
+++ b/app/qml/pages/EMOBActualValuesPageDC.qml
@@ -21,7 +21,6 @@ Item {
         height: model.rowCount() * rowHeight
         boundsBehavior: Flickable.StopAtBounds
         anchors.verticalCenter: parent.verticalCenter
-        anchors.horizontalCenter: parent.horizontalCenter
         anchors.left: parent.left
         anchors.right: parent.right
         delegate: Component {


### PR DESCRIPTION
Do not specify left, right, and horizontalCenter anchors at the same time