### PR TITLE
SaveLogAndDumps: increase timeout to prevent false negative

### DIFF
--- a/lib/lib-gui/qmlfileio.cpp
+++ b/lib/lib-gui/qmlfileio.cpp
@@ -197,7 +197,7 @@ bool QmlFileIO::startWriteJournalctlOnUsb(QVariant versionMap, QString serverIp)
         else
             jsonPath = ""; // service accepts empty version parameter
 
-        m_simpleCmdIoClient = std::make_unique<SimpleCmdIoClient>(serverIp, 5000, 25000);
+        m_simpleCmdIoClient = std::make_unique<SimpleCmdIoClient>(serverIp, 5000, 90000);
         connect(m_simpleCmdIoClient.get(), &SimpleCmdIoClient::sigCmdFinish,
                 this, &QmlFileIO::onSimpleCmdFinish);
         QString unescapedPath = m_mountedPaths[0].replace("\\040", " ");


### PR DESCRIPTION
since this is a client/server architecture, the client sends the command to initiate the copy of logs and dumps to the server, and waits for the success response.  At the same time the client has a timeout of x seconds in which it expects the response, otherwise it will indicate via GUI the failure of the copying/moving of the desired files. 

When devices run for a long time over several days, or large core dumps are to be copied, the time needed to fulfill the task can exceed the timeout of 25seconds. In these cases, the GUI will communicate to the user, the copying process has failed, because no success response from the server within the timeout. The server in turn will finish the copying of the files in the background without the user knowing. 

To prevent this, the timeout is increased, until a better solution is found. 